### PR TITLE
docs: add contact options

### DIFF
--- a/docs/contact.md
+++ b/docs/contact.md
@@ -1,0 +1,8 @@
+# Contact
+
+Have a question or want to share feedback? We’d love to hear from you.
+
+[:octicons-comment-discussion-16: Start a GitHub discussion](https://github.com/apnea-scrap/apnea-scrap-lab/discussions/new){ .md-button .md-button--primary }
+
+[:octicons-bug-16: Open an issue](https://github.com/apnea-scrap/apnea-scrap-lab/issues/new){ .md-button }
+

--- a/mkdocs.base.yml
+++ b/mkdocs.base.yml
@@ -15,6 +15,9 @@ theme:
     - search.highlight
     - search.suggest
     - content.code.copy
+    - content.action.edit
+    - content.action.discuss
+    - content.action.issue
     - toc.integrate
   logo: assets/logo.svg
   favicon: assets/favicon.png
@@ -27,6 +30,12 @@ theme:
     - scheme: slate
       primary: blue
       accent: indigo
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/apnea-scrap/apnea-scrap-lab/discussions
+      name: GitHub discussions
 
 nav:
   - Home: index.md
@@ -59,6 +68,7 @@ nav:
           - "Surface finish v1 — peel‑ply texture": techniques/surface-finish/v1.md
       - Vacuum gauge:
           - "Vacuum gauge v1 — syringe gauge": techniques/vacuum-gauge/v1-syringe-gauge.md
+  - Contact: contact.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- add contact page linking to GitHub discussions
- enable Material theme contact actions and social link

## Testing
- `pip install -r requirements.txt`
- `mkdocs build -f mkdocs.local.yml --site-dir site`


------
https://chatgpt.com/codex/tasks/task_e_68b074ff2f78832c9ace14f37311c3b6