### PR TITLE
Add blog to site navigation

### DIFF
--- a/mkdocs.base.yml
+++ b/mkdocs.base.yml
@@ -64,6 +64,7 @@ nav:
           - "Surface finish v1 — peel‑ply texture": techniques/surface-finish/v1.md
       - Vacuum gauge:
           - "Vacuum gauge v1 — syringe gauge": techniques/vacuum-gauge/v1-syringe-gauge.md
+  - Blog: blog/index.md
   - Contact: contact.md
 
 markdown_extensions:


### PR DESCRIPTION
## Summary
- Move Blog link ahead of Contact in MkDocs navigation so blog appears before the Contact page

## Testing
- `pip install -r requirements.txt`
- `mkdocs build -f mkdocs.local.yml --site-dir site`


------
https://chatgpt.com/codex/tasks/task_e_68b2a2025af4832ca1654bc6e2a06048