### PR TITLE
Add status banners for project and technique pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Macros live in `main.py`.
 
 - `{{ yt("VIDEO_ID", "Title") }}` embeds a responsive privacy friendly YouTube iframe
 - `{{ versions_table() }}` builds a version comparison table for the current folder based on front matter metadata
+- `{{ status_banner() }}` shows a coloured banner with the current page status
 
 Restart `mkdocs serve` if you modify `main.py` to reload macros.
 

--- a/docs/css/status-banner.css
+++ b/docs/css/status-banner.css
@@ -1,0 +1,11 @@
+.status-banner {
+    padding: 8px 12px;
+    color: #fff;
+    font: 500 14px/1.3 system-ui, sans-serif;
+    text-align: center;
+    margin-bottom: 1em;
+    background: #555;
+}
+
+.status-banner.status-active { background: #2e7d32; }
+.status-banner.status-research { background: #0277bd; }

--- a/docs/projects/neck-weight/v1-shot-inner-tube.md
+++ b/docs/projects/neck-weight/v1-shot-inner-tube.md
@@ -8,4 +8,5 @@ time_to_implement: 1
 waiting_time: 0
 ---
 # Neck weight v1 — shot in inner tube
+{{ status_banner() }}
 Cheap, tool‑light build; sleeve the tube for safety.

--- a/docs/projects/neck-weight/v2-molded-sleeve.md
+++ b/docs/projects/neck-weight/v2-molded-sleeve.md
@@ -8,4 +8,5 @@ time_to_implement: 3
 waiting_time: 12
 ---
 # Neck weight v2 — molded sleeve
+{{ status_banner() }}
 Encapsulated core, smooth finish, front quick‑release.

--- a/docs/techniques/buoyancy-test/v1-bathtub.md
+++ b/docs/techniques/buoyancy-test/v1-bathtub.md
@@ -7,4 +7,5 @@ time_to_implement: 0.5
 waiting_time: 0
 ---
 # Buoyancy test v1 — bathtub
+{{ status_banner() }}
 Basic procedure for checking buoyancy using a pool test.

--- a/docs/techniques/carbon-layup/v1/wet-layup.md
+++ b/docs/techniques/carbon-layup/v1/wet-layup.md
@@ -7,6 +7,7 @@ time_to_implement: 3
 waiting_time: 12
 ---
 # Carbon layup v1 — wet layup
+{{ status_banner() }}
 
 Baseline recipe with 0/90 twill and simple taper.
 

--- a/docs/techniques/cutting-templates/v1/paper-laminate.md
+++ b/docs/techniques/cutting-templates/v1/paper-laminate.md
@@ -7,6 +7,7 @@ time_to_implement: 3
 waiting_time: 0
 ---
 # Cutting template v1 — paper laminate
+{{ status_banner() }}
 
 This technique shows how to create a cutting template for fins using laminated paper.
 

--- a/docs/techniques/flex-test-rig/v1-weight-belt-test.md
+++ b/docs/techniques/flex-test-rig/v1-weight-belt-test.md
@@ -7,6 +7,7 @@ time_to_implement: 1
 waiting_time: 0
 ---
 # Flex test rig v1 — weight belt test
+{{ status_banner() }}
 
 **Goal**
 Measure how much load makes the **tip vertical (90°)** and where the blade bends (root, mid, tip).

--- a/docs/techniques/glue-fin-rails/v1.md
+++ b/docs/techniques/glue-fin-rails/v1.md
@@ -8,4 +8,5 @@ time_to_implement: 1
 waiting_time: 12
 ---
 # Glue fin rails v1 — polyurethane adhesive
+{{ status_banner() }}
 Rubber rails, light clamp pressure, full cure overnight.

--- a/docs/techniques/laminating-base/v1/wood-support.md
+++ b/docs/techniques/laminating-base/v1/wood-support.md
@@ -7,6 +7,7 @@ time_to_implement: 3
 waiting_time: 0
 ---
 # Laminating base v1 — acrylic with wood support
+{{ status_banner() }}
 
 25° wooden base with acrylic sheets for laminating carbon fin blades.
 

--- a/docs/techniques/laminating-base/v2/acrylic-wedges.md
+++ b/docs/techniques/laminating-base/v2/acrylic-wedges.md
@@ -8,6 +8,7 @@ time_to_implement: 1
 waiting_time: 0
 ---
 # Laminating base v2 — acrylic with wedge supports
+{{ status_banner() }}
 
 This document describes how to build a modular acrylic base with wedge supports for laminating carbon fins.
 The example shown is for a **70 × 70 cm monofin**, but the same technique can be adapted for **bifins** or other blade sizes.

--- a/docs/techniques/surface-finish/v1.md
+++ b/docs/techniques/surface-finish/v1.md
@@ -8,4 +8,5 @@ time_to_implement: 1
 waiting_time: 12
 ---
 # Surface finish v1 — peel‑ply texture
+{{ status_banner() }}
 Clean, matte finish straight from the bag; very light.

--- a/docs/techniques/vacuum-gauge/v1-syringe-gauge.md
+++ b/docs/techniques/vacuum-gauge/v1-syringe-gauge.md
@@ -8,6 +8,7 @@ time_to_implement: 1
 waiting_time: 0
 ---
 # Vacuum gauge v1 — syringe gauge
+{{ status_banner() }}
 
 A simple gauge to monitor mild vacuum (~81 kPa absolute, −20 kPa gauge) directly **inside** a vacuum bag.
 It uses Boyle’s law: trapped air expands as pressure drops, moving a rubber plunger seal you can read through the bag.

--- a/main.py
+++ b/main.py
@@ -57,3 +57,13 @@ def define_env(env):
         for link, status, cost, impl, wait in rows:
             lines.append(f"| {link} | {status} | {cost} | {impl} | {wait} |")
         return "\n".join(lines)
+
+    @env.macro
+    def status_banner(status: str | None = None) -> str:
+        meta = read_meta(Path(env.page.file.abs_src_path))
+        status = status or meta.get("status")
+        if not status:
+            return ""
+        status_class = status.lower().replace(" ", "-")
+        return f'<div class="status-banner status-{status_class}">{status.title()}</div>'
+

--- a/mkdocs.base.yml
+++ b/mkdocs.base.yml
@@ -36,6 +36,9 @@ extra:
       link: https://github.com/apnea-scrap/apnea-scrap-lab/discussions
       name: GitHub Discussions
 
+extra_css:
+  - css/status-banner.css
+
 nav:
   - Home: index.md
   - Projects:

--- a/mkdocs.local.yml
+++ b/mkdocs.local.yml
@@ -6,4 +6,5 @@ site_url: !ENV [MKDOCS_SITE_URL, 'http://127.0.0.1:8000/local/something']
 extra_javascript:
   - js/local-banner.js
 extra_css:
+  - css/status-banner.css
   - css/local-banner.css

--- a/mkdocs.preview.yml
+++ b/mkdocs.preview.yml
@@ -11,4 +11,5 @@ theme:
 extra_javascript:
   - js/preview-banner.js
 extra_css:
+  - css/status-banner.css
   - css/preview-banner.css


### PR DESCRIPTION
## Summary
- add `status_banner` macro to render page status
- style status banners and load CSS across builds
- display status banners on all project and technique versions

## Testing
- `pip install -r requirements.txt`
- `mkdocs build -f mkdocs.local.yml --site-dir site`


------
https://chatgpt.com/codex/tasks/task_e_68bc3b5c4f8c832caebd21528b35bdea