### PR TITLE
Add Praveen-focused hero showcase to homepage

### DIFF
--- a/docs/css/praveen-hero.css
+++ b/docs/css/praveen-hero.css
@@ -1,0 +1,112 @@
+.praveen-hero {
+  position: relative;
+  margin: 2.5rem 0 3rem;
+  padding: 2.8rem 3rem;
+  border-radius: 1.6rem;
+  background: linear-gradient(135deg, rgba(63, 81, 181, 0.96), rgba(0, 172, 193, 0.85));
+  color: #f5f7ff;
+  overflow: hidden;
+  box-shadow: 0 1.6rem 3.4rem rgba(33, 150, 243, 0.18);
+}
+
+.praveen-hero::before {
+  content: "";
+  position: absolute;
+  inset: -20% auto auto -25%;
+  width: 16rem;
+  height: 16rem;
+  border-radius: 50%;
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.22), transparent 70%);
+  filter: blur(0.5px);
+}
+
+.praveen-hero::after {
+  content: "";
+  position: absolute;
+  inset: auto -30% -35% auto;
+  width: 22rem;
+  height: 22rem;
+  border-radius: 50%;
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.14), transparent 65%);
+  transform: rotate(18deg);
+}
+
+.praveen-hero h2 {
+  margin-top: 0;
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  letter-spacing: 0.02em;
+}
+
+.praveen-hero p {
+  font-size: clamp(1.05rem, 1.8vw, 1.2rem);
+  max-width: 46rem;
+  line-height: 1.7;
+}
+
+.praveen-hero ul {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 1.1rem;
+  padding-left: 1.2rem;
+  margin: 2rem 0 2.4rem;
+  list-style: none;
+}
+
+.praveen-hero li {
+  background: rgba(13, 71, 161, 0.35);
+  padding: 1rem 1.2rem;
+  border-radius: 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 0.7rem 1.8rem rgba(6, 35, 99, 0.24);
+  line-height: 1.5;
+}
+
+.praveen-hero li strong {
+  display: block;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.85);
+  margin-bottom: 0.4rem;
+}
+
+.praveen-hero .praveen-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.9rem 1.6rem;
+  border-radius: 999px;
+  background: #fff;
+  color: #0d47a1;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.95rem;
+  box-shadow: 0 1rem 2.2rem rgba(255, 255, 255, 0.28);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.praveen-hero .praveen-cta:hover,
+.praveen-hero .praveen-cta:focus {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 1.4rem 2.6rem rgba(255, 255, 255, 0.42);
+  text-decoration: none;
+}
+
+.praveen-hero .praveen-cta svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  fill: currentColor;
+}
+
+@media (max-width: 600px) {
+  .praveen-hero {
+    padding: 2.2rem 1.8rem;
+    border-radius: 1.2rem;
+  }
+
+  .praveen-hero ul {
+    margin: 1.6rem 0 2rem;
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,28 @@
 # ApneaScrap Lab
 DIY freediving gear — project versions and results.
 
+<div class="praveen-hero" markdown="1">
+
+## Hey Praveen — ready for a record-breaking dive?
+
+ApneaScrap Lab has been obsessing over flow, flex, and feel. Consider this your personal tour of the latest breakthroughs before they even hit open water.
+
+- **Fluid Flex Lab**  
+  Rail geometry and carbon layups mapped to your dolphin kick cadence, so the blade snaps back with precision instead of slapping water.
+- **Pressure-Proof Craft**  
+  Vacuum-bagged laminates cured with aerospace resins for a warp-free spine that holds strong even when your dives punch past 30 meters.
+- **Telemetry-Ready Core**  
+  Embedded channels and sensor pockets that let you drop in data loggers for split-second feedback on each descent.
+
+<a class="praveen-cta" href="projects/monofin/index.md">
+  Dive into the specs
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path d="M5 12h12.17l-3.59-3.59L14 7l6 6-6 6-0.41-1.41L17.17 13H5z" />
+  </svg>
+</a>
+
+</div>
+
 - [🤿 **Short fins**](projects/short-fins/index.md)
 - [🐬 **Monofin**](projects/monofin/index.md)
 - [🏋️ **Neck weight**](projects/neck-weight/index.md)

--- a/mkdocs.base.yml
+++ b/mkdocs.base.yml
@@ -38,6 +38,7 @@ extra:
 
 extra_css:
   - css/status-banner.css
+  - css/praveen-hero.css
 
 nav:
   - Home: index.md

--- a/mkdocs.local.yml
+++ b/mkdocs.local.yml
@@ -7,4 +7,5 @@ extra_javascript:
   - js/local-banner.js
 extra_css:
   - css/status-banner.css
+  - css/praveen-hero.css
   - css/local-banner.css

--- a/mkdocs.preview.yml
+++ b/mkdocs.preview.yml
@@ -12,4 +12,5 @@ extra_javascript:
   - js/preview-banner.js
 extra_css:
   - css/status-banner.css
+  - css/praveen-hero.css
   - css/preview-banner.css


### PR DESCRIPTION
## Summary
- add a hero callout on the home page welcoming Praveen with lab highlights and CTA
- create bespoke styling for the hero block to deliver an eye-catching gradient glassmorphism treatment
- register the new stylesheet across base, local, and preview MkDocs configurations so it loads in every environment

## Testing
- mkdocs build -f mkdocs.local.yml --site-dir site

------
https://chatgpt.com/codex/tasks/task_e_68d2d823ebb0832ca59b2be3eca0d3ac