### PR TITLE
Add RSS feed plugin configuration

### DIFF
--- a/mkdocs.base.yml
+++ b/mkdocs.base.yml
@@ -119,6 +119,11 @@ plugins:
       blog_toc: true
   - tags:
       tags_file: blog/tags.md
+  - rss:
+      match_path: "blog/posts/.*"
+      date_from_meta:
+        as_creation: date.created
+        as_update: date.updated
 
 hooks:
   - shared/hooks/status_banner_assets.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs==1.6.1
 mkdocs-material==9.6.16
 mkdocs-macros-plugin==1.3.9
+mkdocs-rss-plugin==1.12.1


### PR DESCRIPTION
## Summary
- configure the MkDocs RSS plugin so blog posts are published to a feed that tracks creation and update dates
- add the mkdocs-rss-plugin dependency to the documentation requirements list

## Testing
- `pip install -r requirements.txt` *(fails: PyPI proxy blocks access to mkdocs-rss-plugin)*
- `mkdocs build -f mkdocs.local.yml --site-dir site` *(fails: mkdocs-rss-plugin not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d515e41fc4832cb5f4d05ec18c912e