### PR TITLE
Add Giscus comments to blog posts

### DIFF
--- a/mkdocs.base.yml
+++ b/mkdocs.base.yml
@@ -6,6 +6,7 @@ edit_uri: edit/main/docs/
 
 theme:
   name: material
+  custom_dir: overrides
   language: en
   features:
     - navigation.tabs

--- a/overrides/partials/comments.html
+++ b/overrides/partials/comments.html
@@ -1,0 +1,17 @@
+{% if page.file.src_uri.startswith('blog/posts') %}
+<script src="https://giscus.app/client.js"
+        data-repo="apnea-scrap/apnea-scrap-lab"
+        data-repo-id="R_kgDOPda6yA"
+        data-category="Blog Comments"
+        data-category-id="DIC_kwDOPda6yM4Cv4VY"
+        data-mapping="title"
+        data-strict="1"
+        data-reactions-enabled="1"
+        data-emit-metadata="1"
+        data-input-position="top"
+        data-theme="preferred_color_scheme"
+        data-lang="en"
+        crossorigin="anonymous"
+        async>
+</script>
+{% endif %}


### PR DESCRIPTION
## Summary
- enable the Material overrides directory across builds so partial overrides are loaded
- add a comments partial that embeds the configured Giscus widget on blog posts

## Testing
- mkdocs build -f mkdocs.local.yml --site-dir site

------
https://chatgpt.com/codex/tasks/task_e_68d523420238832ca5a9595d99dff37c