### PR TITLE
Add comment note and discussion links above giscus widget

### DIFF
--- a/overrides/partials/comments.html
+++ b/overrides/partials/comments.html
@@ -1,4 +1,13 @@
 {% if page.file.src_uri.startswith('blog/posts') %}
+<p class="comment-note">
+    Have a question, want to share feedback, or continue the discussion? Leave a comment below!
+    Please keep the conversation welcoming and follow the
+    <a href="https://docs.github.com/site-policy/github-terms/github-community-guidelines">GitHub Community Guidelines</a>.
+    This thread mirrors a
+    <a href="https://github.com/apnea-scrap/apnea-scrap-lab/discussions/categories/blog-comments?discussions_q={{ ('"' ~ page.title ~ '" in:title') | urlencode }}"><em>GitHub discussion</em></a>,
+    so you can also join the conversation there.
+</p>
+
 <script src="https://giscus.app/client.js"
         data-repo="apnea-scrap/apnea-scrap-lab"
         data-repo-id="R_kgDOPda6yA"
@@ -14,4 +23,9 @@
         crossorigin="anonymous"
         async>
 </script>
+
+<p class="comment-directly-on-github">
+    Prefer not to authenticate with <a href="https://giscus.app">giscus</a>? You can participate directly on
+    <a href="https://github.com/apnea-scrap/apnea-scrap-lab/discussions/categories/blog-comments?discussions_q={{ ('"' ~ page.title ~ '" in:title') | urlencode }}"><em>GitHub Discussions</em></a> instead.
+</p>
 {% endif %}


### PR DESCRIPTION
## Summary
- add an introductory note above the giscus widget to encourage discussion and link to community guidelines
- surface direct links to the matching GitHub Discussions thread for readers who prefer commenting there

## Testing
- mkdocs build -f mkdocs.local.yml --site-dir site

------
https://chatgpt.com/codex/tasks/task_e_68d5267408d8832c8ed87c0939099915