### PR TITLE
Update versions table naming, ordering, and status styling

### DIFF
--- a/docs/css/status-banner.css
+++ b/docs/css/status-banner.css
@@ -1,12 +1,27 @@
-.status-banner {
-    padding: 8px 12px;
+.status-banner,
+.status-badge {
     color: #fff;
-    font: 500 14px/1.3 system-ui, sans-serif;
-    text-align: center;
-    margin-bottom: 1em;
     background: #555;
 }
 
-.status-banner.status-active { background: #2e7d32; }
-.status-banner.status-research { background: #0277bd; }
-.status-banner.status-superseded { background: #cb0f0f; }
+.status-banner {
+    padding: 8px 12px;
+    font: 500 14px/1.3 system-ui, sans-serif;
+    text-align: center;
+    margin-bottom: 1em;
+}
+
+.status-badge {
+    display: inline-block;
+    padding: 4px 10px;
+    font: 500 12px/1.2 system-ui, sans-serif;
+    border-radius: 999px;
+    text-align: center;
+}
+
+.status-banner.status-active,
+.status-badge.status-active { background: #2e7d32; }
+.status-banner.status-research,
+.status-badge.status-research { background: #0277bd; }
+.status-banner.status-superseded,
+.status-badge.status-superseded { background: #cb0f0f; }


### PR DESCRIPTION
## Summary
- derive versions table link text from the MkDocs navigation so entries match the sidebar names
- show status values as coloured badges that reuse the status banner palette and list versions newest first
- share the status banner colour rules with the new badges via docs CSS

## Testing
- mkdocs build -f mkdocs.local.yml --site-dir site

------
https://chatgpt.com/codex/tasks/task_e_68d9705dadac832c97f28b0526def64a