### PR TITLE
Infer technique BOM purchases from units

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ Open `mkdocs.yml` and add or reorder pages in the `nav:` section.
   bill_of_materials:
     - material: materials/carbon-fiber-fabric.md
       description: 200 g/m² 3K cloth
-      quantity: 0.3
-      unit: m²
-      purchase:
-        region: UK
+      quantity:
+        amount: 0.3
         unit: m² (1 m wide)
     - name: Consumables pack
       description: Gloves, brushes, mixing sticks
-      quantity: 1
+      quantity:
+        amount: 1
+        unit: pack
       unit_cost:
         amount: 3.50
         currency: GBP
@@ -105,6 +105,12 @@ Open `mkdocs.yml` and add or reorder pages in the `nav:` section.
   waiting_time: 12
   ---
   ```
+  Every bill of materials entry must either reference a material page (setting `quantity.unit` so the macro can match a
+  recorded purchase) or provide its own `name`. Use `quantity.amount` for the numerical value and set
+  `quantity.unit` whenever you want to control the rendered unit or are defining an inline item. Provide
+  `quantity.display` if you need full control over how the quantity appears in the rendered table. When linking a
+  material page, skip the legacy `purchase` block—the macro automatically selects the recorded purchase using the
+  `quantity.unit` you provide.
 3. Add `{{ render_bill_of_materials() }}` where you want the rendered table to appear.
 4. The comparison table on the technique index automatically calculates estimated costs from the bill of materials.
 5. Commit and push. The site will rebuild automatically.

--- a/docs/materials/acrylic-sheet.md
+++ b/docs/materials/acrylic-sheet.md
@@ -1,7 +1,6 @@
 ---
 title: Acrylic Sheet
 material:
-  default_unit: sheet
   purchases:
     - supplier: "Amazon"
       url: "https://www.amazon.co.uk/dp/B09TL1SCCD"

--- a/docs/materials/breather-cloth.md
+++ b/docs/materials/breather-cloth.md
@@ -1,13 +1,12 @@
 ---
 title: Breather Cloth
 material:
-  default_unit: metre
   purchases:
     - supplier: "Easy Composites"
       url: "https://www.easycomposites.co.uk/breather-fabric"
       region: UK
       date: 2025-06
-      unit: 5lm pack (1 m wide)
+      unit: 5 m pack (1 m wide)
       price:
         amount: 12.00
         currency: GBP

--- a/docs/materials/butyl-sealing-tape.md
+++ b/docs/materials/butyl-sealing-tape.md
@@ -1,7 +1,6 @@
 ---
 title: Butyl Sealing Tape
 material:
-  default_unit: roll
   purchases:
     - supplier: "Easy Composites"
       url: "https://www.easycomposites.co.uk/vacuum-bagging-sealant-tape"

--- a/docs/materials/carbon-fiber-fabric.md
+++ b/docs/materials/carbon-fiber-fabric.md
@@ -1,7 +1,6 @@
 ---
 title: Carbon Fiber Fabric
 material:
-  default_unit: m²
   purchases:
     - supplier: "Easy Composites"
       url: "https://www.easycomposites.co.uk/200g-black-stuff-22-twill-3k-carbon-fibre-cloth"

--- a/docs/materials/clear-coat-spray.md
+++ b/docs/materials/clear-coat-spray.md
@@ -1,7 +1,6 @@
 ---
 title: Clear Coat Spray
 material:
-  default_unit: can
   purchases:
     - supplier: "Amazon"
       url: "https://www.amazon.co.uk/dp/B004SNLNY2"

--- a/docs/materials/index.md
+++ b/docs/materials/index.md
@@ -4,7 +4,7 @@ title: Materials Directory
 # Materials Directory
 
 A single place to keep track of every consumable, component, or tool that feeds into ApneaScrap Lab builds.
-Each page now stores the **unit of measure** and **purchase history** we have personally recorded so that
+Each page now stores the **purchase history** we have personally recorded so that
 techniques can reference a neutral material while still pointing back to real prices.
 
 Only the regions where we hold purchase data are listed. At the moment that means the United Kingdom.
@@ -18,8 +18,10 @@ When new data comes in for other locales we can extend each page with additional
    - a `{{ render_material_purchases() }}` call so the macro can turn the recorded purchases into tables grouped by region.
 2. Link techniques and projects to the material page instead of hard-coding suppliers inside a build guide.
 3. When logging a new technique version, add a `bill_of_materials` list in the front matter and render it with
-   `{{ render_bill_of_materials() }}`. Reference materials via their page path and provide a `purchase` hint (region, unit,
-   supplier, etc.) so the macro can pull matching price data from the material page automatically.
+   `{{ render_bill_of_materials() }}`. Reference materials via their page path and set `quantity.unit` so the macro can
+   match the recorded purchase data automatically. Skip `purchase` hints on technique entries—the macro infers the
+   correct record from the unit you supply. Quantities default to the chosen purchase unit, so you only need to describe
+   the amount being used.
 
 Need a new material? Duplicate the template below.
 
@@ -27,7 +29,6 @@ Need a new material? Duplicate the template below.
 ---
 title: Example Material
 material:
-  default_unit: example-unit
   purchases:
     - supplier: "Supplier name"
       url: "https://example.com/product"

--- a/docs/materials/laminating-epoxy-system.md
+++ b/docs/materials/laminating-epoxy-system.md
@@ -1,7 +1,6 @@
 ---
 title: Laminating Epoxy System
 material:
-  default_unit: 500 ml kit
   purchases:
     - supplier: "Easy Composites"
       url: "https://www.easycomposites.co.uk/el2-epoxy-laminating-resin"

--- a/docs/materials/peel-ply.md
+++ b/docs/materials/peel-ply.md
@@ -1,13 +1,12 @@
 ---
 title: Peel Ply
 material:
-  default_unit: metre
   purchases:
     - supplier: "Easy Composites"
       url: "https://www.easycomposites.co.uk/peel-ply"
       region: UK
       date: 2025-06
-      unit: 5ml pack (1.5 m wide)
+      unit: 5 m pack (1.5 m wide)
       price:
         amount: 12.00
         currency: GBP

--- a/docs/materials/plastic-to-carbon-adhesive.md
+++ b/docs/materials/plastic-to-carbon-adhesive.md
@@ -1,7 +1,6 @@
 ---
 title: Plastic to Carbon Adhesive
 material:
-  default_unit: syringe
   purchases:
     - supplier: "Amazon"
       url: "https://www.amazon.co.uk/dp/B01IBOK7FE"

--- a/docs/materials/pva-release-agent.md
+++ b/docs/materials/pva-release-agent.md
@@ -1,7 +1,6 @@
 ---
 title: PVA Release Agent
 material:
-  default_unit: 500 ml bottle
   purchases:
     - supplier: "Easy Composites"
       url: "https://www.easycomposites.co.uk/pva-mould-release-agent"

--- a/docs/materials/rubber-fin-rails.md
+++ b/docs/materials/rubber-fin-rails.md
@@ -1,7 +1,6 @@
 ---
 title: Rubber Fin Rails
 material:
-  default_unit: metre
   purchases:
     - supplier: "AliExpress"
       url: "https://www.aliexpress.com/item/1005007590033380.html"

--- a/docs/materials/stackable-plastic-wedges.md
+++ b/docs/materials/stackable-plastic-wedges.md
@@ -1,7 +1,6 @@
 ---
 title: Stackable Plastic Wedges
 material:
-  default_unit: pack
   purchases:
     - supplier: "Amazon"
       url: "https://www.amazon.co.uk/dp/B0FC2GMBXH"

--- a/docs/materials/vacuum-bagging-kit.md
+++ b/docs/materials/vacuum-bagging-kit.md
@@ -1,7 +1,6 @@
 ---
 title: Vacuum Bagging Kit
 material:
-  default_unit: kit
   purchases:
     - supplier: "Amazon"
       url: "https://www.amazon.co.uk/dp/B07RSCPH4N"

--- a/docs/techniques/creating-laminating-base/v1/wood-support.md
+++ b/docs/techniques/creating-laminating-base/v1/wood-support.md
@@ -6,34 +6,36 @@ bill_of_materials:
   - material: materials/acrylic-sheet.md
     name: Acrylic sheet (A3)
     description: 3 mm clear sheet cut to 420 × 297 mm
-    quantity: 1
-    unit: sheet
-    purchase:
-      region: UK
+    quantity:
+      amount: 1
       unit: 1 sheet A3 sheet (2 mm)
   - material: materials/acrylic-sheet.md
     name: Acrylic sheet (A4)
     description: 2 mm clear sheet cut to 210 x 297 mm
-    quantity: 1
-    unit: sheet
-    purchase:
-      region: UK
+    quantity:
+      amount: 1
       unit: 1 sheet A4 sheet (2 mm)
   - name: Softwood board offcuts
     description: 1 cm thick timber for base and angled supports
-    quantity: 1
+    quantity:
+      amount: 1
+      unit: set
     unit_cost:
       amount: 10.00
       currency: GBP
   - name: Angle brackets and screws
     description: Two galvanised brackets with matching screws
-    quantity: 1
+    quantity:
+      amount: 1
+      unit: set
     unit_cost:
       amount: 4.20
       currency: GBP
   - name: Double sided-tape
     description: Thin acrylic tape to secure sheets to timber
-    quantity: 1
+    quantity:
+      amount: 1
+      unit: roll
     unit_cost:
       amount: 2.00
       currency: GBP

--- a/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
+++ b/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
@@ -6,31 +6,34 @@ bill_of_materials:
   - material: materials/acrylic-sheet.md
     name: Acrylic sheet (A3, 2 mm)
     description: Six panels for modular monofin base
-    quantity: 1
-    unit: 6 pack A3 sheet
-    purchase:
-      region: UK
+    quantity:
+      amount: 1
       unit: 6 pack A3 sheet (2 mm)
   - material: materials/stackable-plastic-wedges.md
     name: Stackable plastic wedges
     description: Adjustable supports for the angled foot pocket section
-    quantity: 1
-    unit: pack (18 wedges)
+    quantity:
+      amount: 1
+      unit: pack (18 wedges)
     unit_cost:
       amount: 7.00
       currency: GBP
   - name: Protective plastic sheet
     description: Disposable sheet to protect the bench surface
-    quantity: 1
+    quantity:
+      amount: 1
+      unit: sheet
     unit_cost:
       amount: 1.50
       currency: GBP
   - name: Electrical tape roll
     description: Wide PVC tape to join acrylic seams
-    quantity: 1
+    quantity:
+      amount: 1
+      unit: roll
     unit_cost:
-       amount: 1.00
-       currency: GBP
+      amount: 1.00
+      currency: GBP
 ---
 # {{ parent_child_title() }}
 {{ status_banner() }}

--- a/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
+++ b/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
@@ -5,27 +5,27 @@ waiting_time: 4
 bill_of_materials:
   - material: materials/laminating-epoxy-system.md
     description: Thin finishing coat (approx. 100 ml mixed)
-    quantity: 0.2
-    unit: 500 ml kit
-    purchase:
-      region: UK
+    quantity:
+      amount: 0.2
       unit: 500 ml kit
   - material: materials/clear-coat-spray.md
     description: Three light lacquer passes for UV protection
-    quantity: 0.3
-    unit: can
-    purchase:
-      region: UK
-      unit: 500 ml can
+    quantity:
+      amount: 0.3
+      unit: 400 ml can
   - name: Sandpaper set
     description: 400, 600, and 1000 grit sheets
-    quantity: 1
+    quantity:
+      amount: 1
+      unit: set
     unit_cost:
       amount: 3.00
       currency: GBP
   - name: Printable vinyl decal sheet (optional)
     description: Gloss white adhesive sheet for logos
-    quantity: 0.2
+    quantity:
+      amount: 0.2
+      unit: sheet
     unit_cost:
       amount: 7.50
       currency: GBP

--- a/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
+++ b/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
@@ -5,19 +5,20 @@ waiting_time: 12
 bill_of_materials:
   - material: materials/rubber-fin-rails.md
     description: One pair of soft rubber rails sized for bifin blades
-    quantity: 1
-    unit: pair
-    purchase:
-      region: UK
+    quantity:
+      amount: 2
+      unit: metre
+      display: 2 m (pair of rails)
   - material: materials/plastic-to-carbon-adhesive.md
     description: 25 ml of 3M DP420 mixed with nozzle
-    quantity: 0.5
-    unit: cartridge
-    purchase:
-      region: UK
+    quantity:
+      amount: 0.5
+      unit: 25 ml syringe
   - name: Fold-back clips set
     description: 20 mm binder clips for clamping rails during cure
-    quantity: 1
+    quantity:
+      amount: 1
+      unit: set
     unit_cost:
       amount: 3.00
       currency: GBP

--- a/docs/techniques/laminating-carbon/v1/wet-layup.md
+++ b/docs/techniques/laminating-carbon/v1/wet-layup.md
@@ -5,35 +5,31 @@ waiting_time: 12
 bill_of_materials:
   - material: materials/carbon-fiber-fabric.md
     description: 0.3 m² of 200 g/m² 3K 2/2 twill cloth
-    quantity: 0.3
-    unit: m²
-    purchase:
-      region: UK
+    quantity:
+      amount: 0.3
       unit: m² (1 m wide)
   - material: materials/laminating-epoxy-system.md
     description: 200 g mixed resin (approx. 200 ml)
-    quantity: 0.4
-    unit: 500 ml kit
-    purchase:
-      region: UK
+    quantity:
+      amount: 0.4
       unit: 500 ml kit
   - material: materials/pva-release-agent.md
     description: Two thin coats on the laminating base
-    quantity: 0.07
-    unit: 500 ml bottle
-    purchase:
-      region: UK
-      unit: 500 ml bottle
+    quantity:
+      amount: 0.175
+      unit: 200 ml bottle
+      display: 35 ml (two thin coats)
   - material: materials/peel-ply.md
     description: Two layers cut to the blade outline
-    quantity: 0.6
-    unit: metre
-    purchase:
-      region: UK
-      unit: linear metre (1.5 m wide)
+    quantity:
+      amount: 0.12
+      unit: 5 m pack (1.5 m wide)
+      display: 0.6 m (1.5 m wide)
   - name: Consumables pack
     description: Gloves, mixing sticks, acetone wipes
-    quantity: 1
+    quantity:
+      amount: 1
+      unit: pack
     unit_cost:
       amount: 3.50
       currency: GBP

--- a/docs/techniques/measuring-vacuum/v1/syringe-gauge.md
+++ b/docs/techniques/measuring-vacuum/v1/syringe-gauge.md
@@ -5,31 +5,37 @@ waiting_time: 0
 bill_of_materials:
   - name: 10 mL syringe
     description: Thin barrel syringe for plunger travel
-    quantity: 1
+    quantity:
+      amount: 1
     unit_cost:
       amount: 0.80
       currency: GBP
   - name: Luer-lock tip cap
     description: Single cap to seal the syringe tip
-    quantity: 1
+    quantity:
+      amount: 1
     unit_cost:
       amount: 0.20
       currency: GBP
   - name: Candle wax shavings
     description: Small amount to lubricate the rubber seal
-    quantity: 0.05
+    quantity:
+      amount: 0.05
+      unit: block
     unit_cost:
       amount: 2.00
       currency: GBP
   - material: materials/breather-cloth.md
     description: Wrap to protect the gauge inside the bag
-    quantity: 0.1
-    unit: metre
-    purchase:
-      region: UK
+    quantity:
+      amount: 0.1
+      unit: 5 m pack (1 m wide)
+      display: 0.5 m (1 m wide)
   - name: Permanent marker
     description: Fine tip for calibration marks
-    quantity: 1
+    quantity:
+      amount: 1
+      unit: marker
     unit_cost:
       amount: 1.50
       currency: GBP

--- a/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
@@ -3,18 +3,15 @@ status: active
 bill_of_materials:
   - material: materials/vacuum-bagging-kit.md
     description: Heavy-duty storage bag plus compatible hand pump
-    quantity: 1
-    unit: kit
-    purchase:
-      region: UK
+    quantity:
+      amount: 1
       unit: kit
   - material: materials/breather-cloth.md
     description: Wraps part to distribute airflow
-    quantity: 0.5
-    unit: metre
-    purchase:
-      region: UK
-      unit: linear metre (1 m wide)
+    quantity:
+      amount: 0.1
+      unit: 5 m pack (1 m wide)
+      display: 0.5 m (1 m wide)
 time_to_implement: 0.25
 waiting_time: 0
 ---

--- a/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
@@ -3,29 +3,25 @@ status: research
 bill_of_materials:
   - material: materials/vacuum-bagging-kit.md
     description: Manual pump with heavy-duty storage bags for low-cost vacuum pulls
-    quantity: 1
-    unit: kit
-    purchase:
-      region: UK
+    quantity:
+      amount: 1
       unit: kit
   - material: materials/butyl-sealing-tape.md
     description: Continuous bead around the laminating base
-    quantity: 0.4
-    unit: roll
-    purchase:
-      region: UK
+    quantity:
+      amount: 0.4
       unit: 15 m roll (12 mm)
   - material: materials/breather-cloth.md
     description: Under-bag airflow path and resin catch
-    quantity: 0.6
-    unit: metre
-    purchase:
-      region: UK
-      unit: linear metre (1 m wide)
+    quantity:
+      amount: 0.12
+      unit: 5 m pack (1 m wide)
+      display: 0.6 m (1 m wide)
   - name: DIY Vacuum gauge
     description: Inline gauge to monitor vacuum level
-    quantity: 1
-    unit: gauge
+    quantity:
+      amount: 1
+      unit: gauge
     unit_cost:
       amount: 2.00
       currency: GBP


### PR DESCRIPTION
## Summary
- disallow purchase hints on material-linked bill of materials entries and match purchases automatically via `quantity.unit`
- update technique front matter to drop explicit purchase references while aligning units and usage displays with recorded materials
- clarify contributor guidance and correct material unit typos so documentation reflects the new matching behaviour

## Testing
- mkdocs build -f mkdocs.local.yml --site-dir site

------
https://chatgpt.com/codex/tasks/task_e_68da7ed31b48832c8e1ddfa72bc2b1bd