### PR TITLE
Capture tool purposes in tools macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ Open `mkdocs.yml` and add or reorder pages in the `nav:` section.
       unit_cost:
         amount: 3.50
         currency: GBP
+  tools_required:
+    - name: Nitrile gloves
+      purpose: Protect your hands while handling resin
+    - name: Mixing sticks
+      purpose: Blend resin and hardener thoroughly
   time_to_implement: 3
   waiting_time: 12
   ---
@@ -110,10 +115,12 @@ Open `mkdocs.yml` and add or reorder pages in the `nav:` section.
   `quantity.unit` whenever you want to control the rendered unit or are defining an inline item. Provide
   `quantity.display` if you need full control over how the quantity appears in the rendered table. When linking a
   material page, skip the legacy `purchase` block—the macro automatically selects the recorded purchase using the
-  `quantity.unit` you provide.
-3. Add `{{ render_bill_of_materials() }}` where you want the rendered table to appear.
-4. The comparison table on the technique index automatically calculates estimated costs from the bill of materials.
-5. Commit and push. The site will rebuild automatically.
+  `quantity.unit` you provide. List recurring equipment under `tools_required`, adding a `name` for each tool and a
+  short `purpose` that explains why it is needed for the process.
+3. Add `{{ render_tools_required() }}` near the top of the page (for example right after `{{ status_banner() }}`) to render the tools list captured in front matter.
+4. Add `{{ render_bill_of_materials() }}` where you want the rendered table to appear.
+5. The comparison table on the technique index automatically calculates estimated costs from the bill of materials.
+6. Commit and push. The site will rebuild automatically.
 
 ### Embed a YouTube video
 Use the `yt` macro defined in `main.py`.
@@ -130,6 +137,8 @@ Macros live in `main.py`.
 - `{{ yt("VIDEO_ID", "Title") }}` embeds a responsive privacy friendly YouTube iframe
 - `{{ versions_table() }}` builds a version comparison table for the current folder based on front matter metadata
 - `{{ status_banner() }}` shows a coloured banner with the current page status
+- `{{ render_tools_required() }}` outputs the tool list stored in front matter without needing a dedicated page section;
+  each tool entry must provide a `name` and `purpose`
 - `{{ render_bill_of_materials() }}` converts the front matter bill of materials into a table, automatically pulling pricing from linked material pages when available; set `unit_cost: "Inexpensive option"` (or any label string) on a BOM entry when you want the table to display that note instead of a numeric price
 - `{{ render_material_purchases() }}` groups a material page’s purchase history by region and renders supplier tables
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Open `mkdocs.yml` and add or reorder pages in the `nav:` section.
   material page, skip the legacy `purchase` block—the macro automatically selects the recorded purchase using the
   `quantity.unit` you provide. List recurring equipment under `tools_required`, adding a `name` for each tool and a
   short `purpose` that explains why it is needed for the process.
-3. Add `{{ render_tools_required() }}` near the top of the page (for example right after `{{ status_banner() }}`) to render the tools list captured in front matter.
+3. Add a `## Tools Required` section near the top of the page (for example right after `{{ status_banner() }}`) and place `{{ render_tools_required() }}` inside it to render the tools list captured in front matter.
 4. Add `{{ render_bill_of_materials() }}` where you want the rendered table to appear.
 5. The comparison table on the technique index automatically calculates estimated costs from the bill of materials.
 6. Commit and push. The site will rebuild automatically.
@@ -137,7 +137,7 @@ Macros live in `main.py`.
 - `{{ yt("VIDEO_ID", "Title") }}` embeds a responsive privacy friendly YouTube iframe
 - `{{ versions_table() }}` builds a version comparison table for the current folder based on front matter metadata
 - `{{ status_banner() }}` shows a coloured banner with the current page status
-- `{{ render_tools_required() }}` outputs the tool list stored in front matter without needing a dedicated page section;
+- `{{ render_tools_required() }}` outputs the front matter tools list as a table with optional links and notes;
   each tool entry must provide a `name` and `purpose`
 - `{{ render_bill_of_materials() }}` converts the front matter bill of materials into a table, automatically pulling pricing from linked material pages when available; set `unit_cost: "Inexpensive option"` (or any label string) on a BOM entry when you want the table to display that note instead of a numeric price
 - `{{ render_material_purchases() }}` groups a material page’s purchase history by region and renders supplier tables

--- a/docs/techniques/creating-laminating-base/v1/wood-support.md
+++ b/docs/techniques/creating-laminating-base/v1/wood-support.md
@@ -50,9 +50,6 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
-## Tools Required
-{{ render_tools_required() }}
-
 25° wooden base with acrylic sheets for laminating carbon fin blades.
 
 ## Goal
@@ -73,6 +70,9 @@ Create a rigid angled surface to support fin blades during lamination.
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
+
+## Tools Required
+{{ render_tools_required() }}
 
 ## Reference Images
 

--- a/docs/techniques/creating-laminating-base/v1/wood-support.md
+++ b/docs/techniques/creating-laminating-base/v1/wood-support.md
@@ -2,6 +2,15 @@
 status: active
 time_to_implement: 3
 waiting_time: 0
+tools_required:
+  - name: Wood saw
+    purpose: Cut the laminating base supports to length
+  - name: Screwdriver for angle brackets
+    purpose: Drive screws to secure brackets and maintain the angle
+  - name: Measuring tools (square, protractor, tape measure)
+    purpose: Check angles and dimensions while setting up the base
+  - name: Sandpaper for smoothing wood edges
+    purpose: Remove splinters and soften corners that contact the laminate
 bill_of_materials:
   - material: materials/acrylic-sheet.md
     name: Acrylic sheet (A3)
@@ -41,6 +50,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_tools_required() }}
+
 25° wooden base with acrylic sheets for laminating carbon fin blades.
 
 ## Goal
@@ -62,13 +73,7 @@ Create a rigid angled surface to support fin blades during lamination.
 
 {{ render_bill_of_materials() }}
 
-## Tools Required
-
-- **Cutting Tools:** Wood saw.
-- **Assembly Tools:** Screwdriver and screws for securing brackets.
-- **Measurement and Finishing:** Measuring tools (square, protractor, tape measure). Sandpaper for smoothing wood edges.
-
-## Reference Images 
+## Reference Images
 
 | ![Support Structure](support_all.jpeg) | ![Brackets and Side](support_brakets.jpeg) |
 |----------------------------------------|--------------------------------------------|

--- a/docs/techniques/creating-laminating-base/v1/wood-support.md
+++ b/docs/techniques/creating-laminating-base/v1/wood-support.md
@@ -50,6 +50,7 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+## Tools Required
 {{ render_tools_required() }}
 
 25° wooden base with acrylic sheets for laminating carbon fin blades.

--- a/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
+++ b/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
@@ -43,9 +43,6 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
-## Tools Required
-{{ render_tools_required() }}
-
 This document describes how to build a modular acrylic base with wedge supports for laminating carbon fins.
 The example shown is for a **70 × 70 cm monofin**, but the same technique can be adapted for **bifins** or other blade sizes.
 
@@ -61,6 +58,9 @@ Provide a modular surface with adjustable wedges to support blades during lamina
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
+
+## Tools Required
+{{ render_tools_required() }}
 
 ## Time Required
 - **Base assembly:** ~30 minutes  

--- a/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
+++ b/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
@@ -43,6 +43,7 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+## Tools Required
 {{ render_tools_required() }}
 
 This document describes how to build a modular acrylic base with wedge supports for laminating carbon fins.

--- a/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
+++ b/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
@@ -2,6 +2,15 @@
 status: research
 time_to_implement: 1
 waiting_time: 0
+tools_required:
+  - name: Isopropyl alcohol and cloth
+    purpose: Clean acrylic edges before applying tape
+  - name: Scissors or knife
+    purpose: Trim electrical tape to length
+  - name: Measuring tape or ruler
+    purpose: Align wedges consistently across the base
+  - name: Squeegee, roller, or thumb pressure
+    purpose: Press the tape firmly onto the acrylic for a flat seal
 bill_of_materials:
   - material: materials/acrylic-sheet.md
     name: Acrylic sheet (A3, 2 mm)
@@ -34,6 +43,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_tools_required() }}
+
 This document describes how to build a modular acrylic base with wedge supports for laminating carbon fins.
 The example shown is for a **70 × 70 cm monofin**, but the same technique can be adapted for **bifins** or other blade sizes.
 
@@ -49,12 +60,6 @@ Provide a modular surface with adjustable wedges to support blades during lamina
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
-
-## Tools Required
-- Isopropyl alcohol and cloth (for cleaning sheet edges)  
-- Scissors or knife (for trimming electrical tape)  
-- Measuring tape or ruler (for alignment)  
-- Squeegee, roller, or thumb pressure (for pressing tape flush)  
 
 ## Time Required
 - **Base assembly:** ~30 minutes  

--- a/docs/techniques/cutting-cured-carbon/v1/junior-hacksaw.md
+++ b/docs/techniques/cutting-cured-carbon/v1/junior-hacksaw.md
@@ -13,15 +13,15 @@ tools_required:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
-## Tools Required
-{{ render_tools_required() }}
-
 ## Goal
 To cut cured carbon laminate into the desired shape using a simple junior hacksaw method, ensuring a clean fit into the final assembly.
 
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
+
+## Tools Required
+{{ render_tools_required() }}
 
 ## Instructions (step-by-step)
 0. **Safety**: Wear gloves, eye protection, and a dust mask. Perform all steps in a well-ventilated area.

--- a/docs/techniques/cutting-cured-carbon/v1/junior-hacksaw.md
+++ b/docs/techniques/cutting-cured-carbon/v1/junior-hacksaw.md
@@ -13,6 +13,7 @@ tools_required:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+## Tools Required
 {{ render_tools_required() }}
 
 ## Goal

--- a/docs/techniques/cutting-cured-carbon/v1/junior-hacksaw.md
+++ b/docs/techniques/cutting-cured-carbon/v1/junior-hacksaw.md
@@ -2,9 +2,18 @@
 status: active
 time_to_implement: 1
 waiting_time: 0
+tools_required:
+  - name: Junior hacksaw with a fine-tooth metal blade
+    purpose: Cut the cured carbon cleanly without fraying
+  - name: Metal file
+    purpose: Deburr and smooth the cut edges
+  - name: Safety goggles, dust mask, and protective gloves
+    purpose: Shield eyes, lungs, and skin from carbon dust and splinters
 ---
 # {{ parent_child_title() }}
 {{ status_banner() }}
+
+{{ render_tools_required() }}
 
 ## Goal
 To cut cured carbon laminate into the desired shape using a simple junior hacksaw method, ensuring a clean fit into the final assembly.
@@ -12,11 +21,6 @@ To cut cured carbon laminate into the desired shape using a simple junior hacksa
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
-
-## Tools Required
-- Junior hacksaw with a fine-tooth metal blade
-- Metal file
-- Safety goggles, dust mask, and protective gloves
 
 ## Instructions (step-by-step)
 0. **Safety**: Wear gloves, eye protection, and a dust mask. Perform all steps in a well-ventilated area.

--- a/docs/techniques/cutting-template/v1/paper-laminate.md
+++ b/docs/techniques/cutting-template/v1/paper-laminate.md
@@ -2,6 +2,11 @@
 status: active
 time_to_implement: 0.5
 waiting_time: 0
+tools_required:
+  - name: Scissors or precision cutting tool
+    purpose: Trim the laminated template to the traced outline
+  - name: Pen or pencil for tracing
+    purpose: Mark the foot pocket contour onto the laminate
 bill_of_materials:
   - name: A4 sheets
     description: 250 gsm sheets for tracing and stiffness
@@ -16,6 +21,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_tools_required() }}
+
 This technique shows how to create a cutting template for fins using laminated paper.
 
 ## Goal
@@ -27,10 +34,6 @@ Produce a durable template that matches the foot pocket outline.
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
-
-## Tools Required
-- Scissors or precision cutting tool
-- Pen or pencil for tracing
 
 ## Reference Images
 

--- a/docs/techniques/cutting-template/v1/paper-laminate.md
+++ b/docs/techniques/cutting-template/v1/paper-laminate.md
@@ -21,9 +21,6 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
-## Tools Required
-{{ render_tools_required() }}
-
 This technique shows how to create a cutting template for fins using laminated paper.
 
 ## Goal
@@ -35,6 +32,9 @@ Produce a durable template that matches the foot pocket outline.
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
+
+## Tools Required
+{{ render_tools_required() }}
 
 ## Reference Images
 

--- a/docs/techniques/cutting-template/v1/paper-laminate.md
+++ b/docs/techniques/cutting-template/v1/paper-laminate.md
@@ -21,6 +21,7 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+## Tools Required
 {{ render_tools_required() }}
 
 This technique shows how to create a cutting template for fins using laminated paper.

--- a/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
+++ b/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
@@ -47,6 +47,7 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+## Tools Required
 {{ render_tools_required() }}
 
 ## Goal

--- a/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
+++ b/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
@@ -47,17 +47,17 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
-## Tools Required
-{{ render_tools_required() }}
-
 ## Goal
 
-To apply a protective and aesthetic finish to cured carbon blades by sealing, smoothing, and clear-coating the surface.  
+To apply a protective and aesthetic finish to cured carbon blades by sealing, smoothing, and clear-coating the surface.
 This improves durability, protects against moisture, enhances gloss, and provides the option for custom decals.
 
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
+
+## Tools Required
+{{ render_tools_required() }}
 
 ## Instructions (step-by-step)
 

--- a/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
+++ b/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
@@ -2,6 +2,19 @@
 status: active
 time_to_implement: 1
 waiting_time: 4
+tools_required:
+  - name: Mixing cups
+    purpose: Measure and combine resin with hardener
+  - name: Small brush
+    purpose: Spread the epoxy and clear coat evenly
+  - name: Sandpaper (400 / 600 grit; 1000 grit optional)
+    purpose: Level and smooth the cured surface between coats
+  - name: Gloves
+    purpose: Keep resin and solvents off your hands
+  - name: Eye protection
+    purpose: Guard against splashes while applying resin
+  - name: Well-ventilated workspace
+    purpose: Provide airflow to control fumes and cure safely
 bill_of_materials:
   - material: materials/laminating-epoxy-system.md
     description: Thin finishing coat (approx. 100 ml mixed)
@@ -34,6 +47,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_tools_required() }}
+
 ## Goal
 
 To apply a protective and aesthetic finish to cured carbon blades by sealing, smoothing, and clear-coating the surface.  
@@ -42,15 +57,6 @@ This improves durability, protects against moisture, enhances gloss, and provide
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
-
-## Tools Required
-
-- Mixing cups (for resin + hardener)
-- Small brush (for epoxy layer)
-- Sandpaper (400 / 600 grit; 1000 grit optional for higher gloss)
-- Gloves
-- Eye protection
-- Well-ventilated workspace
 
 ## Instructions (step-by-step)
 

--- a/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
+++ b/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
@@ -2,6 +2,13 @@
 status: active
 time_to_implement: 0.5
 waiting_time: 12
+tools_required:
+  - name: Gloves
+    purpose: Keep the two-part adhesive off your skin
+  - name: Sandpaper (around 400 grit)
+    purpose: Key both surfaces to improve adhesion
+  - name: Window cleaner
+    purpose: Degrease the blade and rails before bonding
 bill_of_materials:
   - material: materials/rubber-fin-rails.md
     description: One pair of soft rubber rails sized for bifin blades
@@ -24,6 +31,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_tools_required() }}
+
 ## Goal
 
 To attach rubber fin rails securely to carbon fiber blades using a strong composite adhesive.  
@@ -32,12 +41,6 @@ The rails protect the blade edges, improve water flow, and extend the blade’s 
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
-
-## Tools Required
-
-- Gloves
-- Sandpaper (around 400 grit)
-- Window cleaner (for cleaning surfaces)
 
 ## Instructions (step-by-step)
 

--- a/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
+++ b/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
@@ -31,17 +31,17 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
-## Tools Required
-{{ render_tools_required() }}
-
 ## Goal
 
-To attach rubber fin rails securely to carbon fiber blades using a strong composite adhesive.  
+To attach rubber fin rails securely to carbon fiber blades using a strong composite adhesive.
 The rails protect the blade edges, improve water flow, and extend the blade’s lifespan.
 
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
+
+## Tools Required
+{{ render_tools_required() }}
 
 ## Instructions (step-by-step)
 

--- a/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
+++ b/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
@@ -31,6 +31,7 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+## Tools Required
 {{ render_tools_required() }}
 
 ## Goal

--- a/docs/techniques/laminating-carbon/v1/wet-layup.md
+++ b/docs/techniques/laminating-carbon/v1/wet-layup.md
@@ -52,6 +52,7 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+## Tools Required
 {{ render_tools_required() }}
 
 Baseline recipe with 0/90 twill and simple taper.

--- a/docs/techniques/laminating-carbon/v1/wet-layup.md
+++ b/docs/techniques/laminating-carbon/v1/wet-layup.md
@@ -2,6 +2,21 @@
 status: active
 time_to_implement: 1
 waiting_time: 12
+tools_required:
+  - name: Nitrile gloves
+    purpose: Protect your hands while handling resin
+  - name: Mixing pots and sticks
+    purpose: Measure and blend epoxy batches
+  - name: Laminating brushes
+    purpose: Wet out the carbon fabric evenly
+  - name: Plastic finned roller (75 mm)
+    purpose: Consolidate layers and push out trapped air
+  - name: Scissors for cutting fabric
+    purpose: Cut reinforcement to the required templates
+  - name: Digital scale
+    purpose: Weigh resin batches for accurate mix ratios
+  - name: Optional vacuum bagging kit
+    purpose: Apply consolidation pressure when available
 bill_of_materials:
   - material: materials/carbon-fiber-fabric.md
     description: 0.3 m² of 200 g/m² 3K 2/2 twill cloth
@@ -37,6 +52,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_tools_required() }}
+
 Baseline recipe with 0/90 twill and simple taper.
 
 ## Goal
@@ -49,18 +66,6 @@ Produce a basic carbon blade using a manual wet layup.
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
-
-- Digital scale accurate to 1 g for measuring resin and hardener.
-- Plastic finned roller (75 mm) to consolidate the laminate.
-
-## Tools Required
-- Nitrile gloves
-- Mixing pots and sticks
-- Laminating brushes
-- Plastic finned roller (75 mm)
-- Scissors for cutting fabric
-- Digital scale
-- Optional: vacuum bagging kit (manual pump plus storage bags)
 
 ## Reference Images
 

--- a/docs/techniques/laminating-carbon/v1/wet-layup.md
+++ b/docs/techniques/laminating-carbon/v1/wet-layup.md
@@ -52,9 +52,6 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
-## Tools Required
-{{ render_tools_required() }}
-
 Baseline recipe with 0/90 twill and simple taper.
 
 ## Goal
@@ -67,6 +64,9 @@ Produce a basic carbon blade using a manual wet layup.
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
+
+## Tools Required
+{{ render_tools_required() }}
 
 ## Reference Images
 

--- a/docs/techniques/measuring-flex/v1/weight-belt-test.md
+++ b/docs/techniques/measuring-flex/v1/weight-belt-test.md
@@ -9,12 +9,31 @@ tools_required:
     purpose: Record the deflection for later comparison
   - name: Angle finder or protractor
     purpose: Measure the bend angle at the target load
+bill_of_materials:
+  - name: Weight belt with pockets
+    description: Holds weights in place to load the fin tip and mid-span
+    quantity:
+      amount: 1
+      unit: belt
+  - name: Dive weights
+    description: Individual weights to create the 2:1 tip-to-mid loading ratio
+    quantity:
+      amount: 3
+      unit: weights
+      display: Mix of weights to reach target load
+  - name: Rigid ruler or printed grid
+    description: Visual reference to observe bend angles along the blade span
+    quantity:
+      amount: 1
+      unit: reference board
+  - name: Masking tape
+    description: Secures the grid or ruler to the support structure
+    quantity:
+      amount: 1
+      unit: roll
 ---
 # {{ parent_child_title() }}
 {{ status_banner() }}
-
-## Tools Required
-{{ render_tools_required() }}
 
 ## Goal
 Measure the load required to make the **tip vertical (90°)** and observe where the blade bends (root, mid, tip).
@@ -24,11 +43,12 @@ Measure the load required to make the **tip vertical (90°)** and observe where 
 - Marks at 0.3 L (root), 0.6 L (mid), and 0.9 L (tip)
 - Weights applied in a 2:1 ratio (tip:mid)
 
-## Materials
-- Weight belt
-- Dive weights
-- Ruler or printed grid
-- Tape for securing the reference grid
+## Bill of Materials
+
+{{ render_bill_of_materials() }}
+
+## Tools Required
+{{ render_tools_required() }}
 
 ## Instructions
 - **Step 1 — Load until tip is vertical**  

--- a/docs/techniques/measuring-flex/v1/weight-belt-test.md
+++ b/docs/techniques/measuring-flex/v1/weight-belt-test.md
@@ -13,6 +13,7 @@ tools_required:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+## Tools Required
 {{ render_tools_required() }}
 
 ## Goal

--- a/docs/techniques/measuring-flex/v1/weight-belt-test.md
+++ b/docs/techniques/measuring-flex/v1/weight-belt-test.md
@@ -2,9 +2,18 @@
 status: superseded
 time_to_implement: 0.25
 waiting_time: 0
+tools_required:
+  - name: Clamp with rubber pads
+    purpose: Secure the blade without marking the rails
+  - name: Camera or smartphone
+    purpose: Record the deflection for later comparison
+  - name: Angle finder or protractor
+    purpose: Measure the bend angle at the target load
 ---
 # {{ parent_child_title() }}
 {{ status_banner() }}
+
+{{ render_tools_required() }}
 
 ## Goal
 Measure the load required to make the **tip vertical (90°)** and observe where the blade bends (root, mid, tip).
@@ -19,11 +28,6 @@ Measure the load required to make the **tip vertical (90°)** and observe where 
 - Dive weights
 - Ruler or printed grid
 - Tape for securing the reference grid
-
-## Tools Required
-- Clamp with rubber pads
-- Camera or smartphone
-- Angle finder or protractor
 
 ## Instructions
 - **Step 1 — Load until tip is vertical**  

--- a/docs/techniques/measuring-flex/v2/kitchen-scale-test.md
+++ b/docs/techniques/measuring-flex/v2/kitchen-scale-test.md
@@ -2,15 +2,17 @@
 status: active
 time_to_implement: 0.25
 waiting_time: 0
+tools_required:
+  - name: Kitchen scale
+    purpose: Measure the load applied during the flex test
 ---
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_tools_required() }}
+
 ## Goal
 Measure the load required to make the **tip vertical (90°)** and observe where the blade bends (root, mid, tip).
-
-## Tools Required
-- Kitchen Scale 
 
 ## Reference Images
 

--- a/docs/techniques/measuring-flex/v2/kitchen-scale-test.md
+++ b/docs/techniques/measuring-flex/v2/kitchen-scale-test.md
@@ -9,6 +9,7 @@ tools_required:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+## Tools Required
 {{ render_tools_required() }}
 
 ## Goal

--- a/docs/techniques/measuring-flex/v2/kitchen-scale-test.md
+++ b/docs/techniques/measuring-flex/v2/kitchen-scale-test.md
@@ -9,11 +9,15 @@ tools_required:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
-## Tools Required
-{{ render_tools_required() }}
-
 ## Goal
 Measure the load required to make the **tip vertical (90°)** and observe where the blade bends (root, mid, tip).
+
+## Bill of Materials
+
+{{ render_bill_of_materials() }}
+
+## Tools Required
+{{ render_tools_required() }}
 
 ## Reference Images
 

--- a/docs/techniques/measuring-vacuum/v1/syringe-gauge.md
+++ b/docs/techniques/measuring-vacuum/v1/syringe-gauge.md
@@ -2,6 +2,11 @@
 status: research
 time_to_implement: 1
 waiting_time: 0
+tools_required:
+  - name: Knife or scissors
+    purpose: Trim tubing and syringe components to length
+  - name: Permanent marker
+    purpose: Mark graduations and reference points on the gauge
 bill_of_materials:
   - name: 10 mL syringe
     description: Thin barrel syringe for plunger travel
@@ -23,6 +28,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_tools_required() }}
+
 A simple gauge to monitor mild vacuum (~81 kPa absolute, −20 kPa gauge) directly **inside** a vacuum bag.
 It uses Boyle’s law: trapped air expands as pressure drops, moving a rubber plunger seal you can read through the bag.
 
@@ -32,10 +39,6 @@ Monitor vacuum level inside a bag using plunger movement.
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
-
-## Tools Required
-- Knife or scissors (for trimming)
-- Permanent marker
 
 ## Instructions (step-by-step)
 1. **Modify plunger**

--- a/docs/techniques/measuring-vacuum/v1/syringe-gauge.md
+++ b/docs/techniques/measuring-vacuum/v1/syringe-gauge.md
@@ -28,9 +28,6 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
-## Tools Required
-{{ render_tools_required() }}
-
 A simple gauge to monitor mild vacuum (~81 kPa absolute, −20 kPa gauge) directly **inside** a vacuum bag.
 It uses Boyle’s law: trapped air expands as pressure drops, moving a rubber plunger seal you can read through the bag.
 
@@ -40,6 +37,9 @@ Monitor vacuum level inside a bag using plunger movement.
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
+
+## Tools Required
+{{ render_tools_required() }}
 
 ## Instructions (step-by-step)
 1. **Modify plunger**

--- a/docs/techniques/measuring-vacuum/v1/syringe-gauge.md
+++ b/docs/techniques/measuring-vacuum/v1/syringe-gauge.md
@@ -28,6 +28,7 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+## Tools Required
 {{ render_tools_required() }}
 
 A simple gauge to monitor mild vacuum (~81 kPa absolute, −20 kPa gauge) directly **inside** a vacuum bag.

--- a/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
@@ -23,9 +23,6 @@ tools_required:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
-## Tools Required
-{{ render_tools_required() }}
-
 ## Goal
 To create a simple, low-cost vacuum environment for small parts using the manual pump and storage bags from the vacuum bagging kit.
 
@@ -38,6 +35,9 @@ To create a simple, low-cost vacuum environment for small parts using the manual
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
+
+## Tools Required
+{{ render_tools_required() }}
 
 ## Reference Images
 

--- a/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
@@ -14,9 +14,16 @@ bill_of_materials:
       display: 0.5 m (1 m wide)
 time_to_implement: 0.25
 waiting_time: 0
+tools_required:
+  - name: Metal file
+    purpose: Smooth base edges so they do not puncture the bag
+  - name: Scissors
+    purpose: Cut breather cloth and consumables to size
 ---
 # {{ parent_child_title() }}
 {{ status_banner() }}
+
+{{ render_tools_required() }}
 
 ## Goal
 To create a simple, low-cost vacuum environment for small parts using the manual pump and storage bags from the vacuum bagging kit.
@@ -30,10 +37,6 @@ To create a simple, low-cost vacuum environment for small parts using the manual
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
-
-## Tools Required
-- Metal file (for smoothing edges of the base or parts)
-- Scissors (for cutting breather cloth)
 
 ## Reference Images
 

--- a/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
@@ -23,6 +23,7 @@ tools_required:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+## Tools Required
 {{ render_tools_required() }}
 
 ## Goal

--- a/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
@@ -37,9 +37,6 @@ tools_required:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
-## Tools Required
-{{ render_tools_required() }}
-
 ## Goal
 To enable vacuum bagging of larger parts by sealing a cut vacuum bag directly to the laminating base using butyl tape, while achieving a controlled and measurable vacuum level.
 
@@ -51,6 +48,9 @@ To enable vacuum bagging of larger parts by sealing a cut vacuum bag directly to
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
+
+## Tools Required
+{{ render_tools_required() }}
 
 ## Instructions (step-by-step)
 

--- a/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
@@ -26,9 +26,18 @@ bill_of_materials:
 
 time_to_implement: 0.5
 waiting_time: 0
+tools_required:
+  - name: Metal roller or rounded tool
+    purpose: Press the butyl sealing tape firmly to the base
+  - name: Scissors or utility knife
+    purpose: Cut the bag film and breather cloth to size
+  - name: Cleaning cloth and window cleaner
+    purpose: Remove dust and grease before sealing the bag edges
 ---
 # {{ parent_child_title() }}
 {{ status_banner() }}
+
+{{ render_tools_required() }}
 
 ## Goal
 To enable vacuum bagging of larger parts by sealing a cut vacuum bag directly to the laminating base using butyl tape, while achieving a controlled and measurable vacuum level.
@@ -41,11 +50,6 @@ To enable vacuum bagging of larger parts by sealing a cut vacuum bag directly to
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
-
-## Tools Required
-- Metal roller or rounded tool (for pressing sealant tape firmly)
-- Scissors or utility knife (for cutting bag film and breather cloth)
-- Cleaning cloth and window cleaner
 
 ## Instructions (step-by-step)
 

--- a/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
@@ -37,6 +37,7 @@ tools_required:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+## Tools Required
 {{ render_tools_required() }}
 
 ## Goal

--- a/main.py
+++ b/main.py
@@ -466,10 +466,11 @@ def define_env(env):
         if not tools:
             return ""
 
-        heading = title if title is not None else "Tools Required"
-        heading_html = f"<strong>{heading}</strong>" if heading else ""
+        table_lines = [
+            "| Tool | Purpose | Notes |",
+            "| --- | --- | --- |",
+        ]
 
-        list_items_parts: list[str] = []
         for tool in tools:
             name_html = escape(tool["name"])
             if tool.get("link"):
@@ -477,24 +478,19 @@ def define_env(env):
                 name_html = f"<a href=\"{href}\">{name_html}</a>"
 
             purpose_html = escape(tool["purpose"])
-            item_body = f"<strong>{name_html}</strong> — {purpose_html}"
 
-            notes = tool.get("notes")
-            if notes:
-                notes_html = notes if str(notes).startswith("<") else escape(str(notes))
-                item_body = f"{item_body}<br><small>{notes_html}</small>"
+            notes_value = tool.get("notes")
+            if notes_value:
+                notes_text = str(notes_value)
+                notes_html = notes_text if notes_text.startswith("<") else escape(notes_text)
+            else:
+                notes_html = ""
 
-            list_items_parts.append(f"<li>{item_body}</li>")
+            table_lines.append(f"| {name_html} | {purpose_html} | {notes_html} |")
 
-        list_items = "".join(list_items_parts)
-        list_html = f"<ul>{list_items}</ul>"
+        table = "\n".join(table_lines)
 
-        if heading_html:
-            content = f"{heading_html}\n{list_html}"
-        else:
-            content = list_html
-
-        return f"<div class=\"tools-required\">\n{content}\n</div>"
+        return f"<div class=\"tools-required\">\n{table}\n</div>"
 
     @env.macro
     def render_bill_of_materials(path: str | None = None) -> str:


### PR DESCRIPTION
## Summary
- require each `tools_required` entry to provide a name and purpose, updating the macro to render the structured details
- document the new tool metadata convention and update the existing technique pages so their tool lists include purposes

## Testing
- mkdocs build -f mkdocs.local.yml --site-dir site

------
https://chatgpt.com/codex/tasks/task_e_68da97902aa8832ca9b7126130be6a4d