### PR TITLE
Standardize tool naming across documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Open `mkdocs.yml` and add or reorder pages in the `nav:` section.
         amount: 3.50
         currency: GBP
   tools_required:
-    - name: Nitrile gloves
+    - name: Gloves
       purpose: Protect your hands while handling resin
     - name: Mixing sticks
       purpose: Blend resin and hardener thoroughly

--- a/docs/techniques/creating-laminating-base/v1/wood-support.md
+++ b/docs/techniques/creating-laminating-base/v1/wood-support.md
@@ -5,11 +5,11 @@ waiting_time: 0
 tools_required:
   - name: Wood saw
     purpose: Cut the laminating base supports to length
-  - name: Screwdriver for angle brackets
+  - name: Screwdriver
     purpose: Drive screws to secure brackets and maintain the angle
-  - name: Measuring tools (square, protractor, tape measure)
-    purpose: Check angles and dimensions while setting up the base
-  - name: Sandpaper for smoothing wood edges
+  - name: Tape measure
+    purpose: Check dimensions while setting up the base; use a square or protractor if you need to verify angles
+  - name: Sandpaper
     purpose: Remove splinters and soften corners that contact the laminate
 bill_of_materials:
   - material: materials/acrylic-sheet.md

--- a/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
+++ b/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
@@ -5,9 +5,9 @@ waiting_time: 0
 tools_required:
   - name: Isopropyl alcohol and cloth
     purpose: Clean acrylic edges before applying tape
-  - name: Scissors or knife
-    purpose: Trim electrical tape to length
-  - name: Measuring tape or ruler
+  - name: Scissors
+    purpose: Trim electrical tape to length (a craft knife also works)
+  - name: Tape measure
     purpose: Align wedges consistently across the base
   - name: Squeegee, roller, or thumb pressure
     purpose: Press the tape firmly onto the acrylic for a flat seal

--- a/docs/techniques/cutting-cured-carbon/v1/junior-hacksaw.md
+++ b/docs/techniques/cutting-cured-carbon/v1/junior-hacksaw.md
@@ -7,8 +7,12 @@ tools_required:
     purpose: Cut the cured carbon cleanly without fraying
   - name: Metal file
     purpose: Deburr and smooth the cut edges
-  - name: Safety goggles, dust mask, and protective gloves
-    purpose: Shield eyes, lungs, and skin from carbon dust and splinters
+  - name: Gloves
+    purpose: Shield skin from carbon dust and splinters
+  - name: Safety goggles
+    purpose: Protect eyes from carbon dust while cutting
+  - name: Dust mask
+    purpose: Prevent inhalation of carbon dust during cutting
 ---
 # {{ parent_child_title() }}
 {{ status_banner() }}
@@ -24,7 +28,7 @@ To cut cured carbon laminate into the desired shape using a simple junior hacksa
 {{ render_tools_required() }}
 
 ## Instructions (step-by-step)
-0. **Safety**: Wear gloves, eye protection, and a dust mask. Perform all steps in a well-ventilated area.
+0. **Safety**: Wear gloves, safety goggles, and a dust mask. Perform all steps in a well-ventilated area.
 1. Attach the cutting template to the cured laminate using electrical tape.
 2. Hold the laminate securely on a stable surface.
 3. Use a junior hacksaw with a fine-tooth metal blade to slowly cut along the template line. Apply steady pressure and avoid forcing the saw.

--- a/docs/techniques/cutting-template/v1/paper-laminate.md
+++ b/docs/techniques/cutting-template/v1/paper-laminate.md
@@ -3,7 +3,7 @@ status: active
 time_to_implement: 0.5
 waiting_time: 0
 tools_required:
-  - name: Scissors or precision cutting tool
+  - name: Scissors
     purpose: Trim the laminated template to the traced outline
   - name: Pen or pencil for tracing
     purpose: Mark the foot pocket contour onto the laminate

--- a/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
+++ b/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
@@ -3,18 +3,16 @@ status: active
 time_to_implement: 1
 waiting_time: 4
 tools_required:
-  - name: Mixing cups
+  - name: Mixing pots
     purpose: Measure and combine resin with hardener
-  - name: Small brush
+  - name: Brushes
     purpose: Spread the epoxy and clear coat evenly
-  - name: Sandpaper (400 / 600 grit; 1000 grit optional)
-    purpose: Level and smooth the cured surface between coats
+  - name: Sandpaper
+    purpose: Level and smooth the cured surface between coats (400, 600, and optional 1000 grit)
   - name: Gloves
     purpose: Keep resin and solvents off your hands
   - name: Eye protection
     purpose: Guard against splashes while applying resin
-  - name: Well-ventilated workspace
-    purpose: Provide airflow to control fumes and cure safely
 bill_of_materials:
   - material: materials/laminating-epoxy-system.md
     description: Thin finishing coat (approx. 100 ml mixed)

--- a/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
+++ b/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
@@ -5,8 +5,8 @@ waiting_time: 12
 tools_required:
   - name: Gloves
     purpose: Keep the two-part adhesive off your skin
-  - name: Sandpaper (around 400 grit)
-    purpose: Key both surfaces to improve adhesion
+  - name: Sandpaper
+    purpose: Key both surfaces to improve adhesion (around 400 grit)
   - name: Window cleaner
     purpose: Degrease the blade and rails before bonding
 bill_of_materials:

--- a/docs/techniques/laminating-carbon/v1/wet-layup.md
+++ b/docs/techniques/laminating-carbon/v1/wet-layup.md
@@ -3,20 +3,20 @@ status: active
 time_to_implement: 1
 waiting_time: 12
 tools_required:
-  - name: Nitrile gloves
+  - name: Gloves
     purpose: Protect your hands while handling resin
-  - name: Mixing pots and sticks
-    purpose: Measure and blend epoxy batches
-  - name: Laminating brushes
+  - name: Mixing pots
+    purpose: Measure epoxy batches before combining
+  - name: Mixing sticks
+    purpose: Blend resin and hardener thoroughly
+  - name: Brushes
     purpose: Wet out the carbon fabric evenly
   - name: Plastic finned roller (75 mm)
     purpose: Consolidate layers and push out trapped air
-  - name: Scissors for cutting fabric
+  - name: Scissors
     purpose: Cut reinforcement to the required templates
   - name: Digital scale
     purpose: Weigh resin batches for accurate mix ratios
-  - name: Optional vacuum bagging kit
-    purpose: Apply consolidation pressure when available
 bill_of_materials:
   - material: materials/carbon-fiber-fabric.md
     description: 0.3 m² of 200 g/m² 3K 2/2 twill cloth
@@ -79,7 +79,7 @@ Produce a basic carbon blade using a manual wet layup.
 
 **0. Safety first**
 
-- Wear **nitrile gloves** and work in a **well-ventilated area** to avoid exposure to harmful fumes.
+- Wear **gloves** and work in a **well-ventilated area** to avoid exposure to harmful fumes.
 
 ---
 
@@ -122,7 +122,7 @@ Produce a basic carbon blade using a manual wet layup.
 1. Once the laminate layers are complete, apply **two layers of peel ply** over the top surface.
    - Peel ply absorbs **excess resin** and helps achieve a uniform finish.
 2. Optional: include a **breather layer** to improve vacuum results.
-3. Optional: if using the vacuum bagging kit, place the prepared laminate inside one of the storage bags, seal it, and apply **vacuum pressure** with the manual pump.
+3. Optional: if using a vacuum bagging kit, place the prepared laminate inside one of the storage bags, seal it, and apply **vacuum pressure** with the manual pump.
 
 ---
 

--- a/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
@@ -29,8 +29,8 @@ waiting_time: 0
 tools_required:
   - name: Metal roller or rounded tool
     purpose: Press the butyl sealing tape firmly to the base
-  - name: Scissors or utility knife
-    purpose: Cut the bag film and breather cloth to size
+  - name: Scissors
+    purpose: Cut the bag film and breather cloth to size (a utility knife also works)
   - name: Cleaning cloth and window cleaner
     purpose: Remove dust and grease before sealing the bag edges
 ---


### PR DESCRIPTION
## Summary
- align tool names across technique pages to use consistent labels for gloves, brushes, mixing pots, sandpaper, scissors, and tape measures
- remove non-tool items from tool lists and split combined PPE entries for clarity
- update README example to match the standardized naming pattern

## Testing
- mkdocs build -f mkdocs.local.yml --site-dir site

------
https://chatgpt.com/codex/tasks/task_e_68dbadf4e220832cb8a6d56b4ed6aa10