### PR TITLE
Reorder reference image sections before bill of materials

### DIFF
--- a/docs/projects/short-fins/v1/power-fin.md
+++ b/docs/projects/short-fins/v1/power-fin.md
@@ -66,16 +66,16 @@ Start with the [Flex predictor modelling](../../../techniques/predicting-flex/v1
 - _TODO: record bending moment targets_
 - _TODO: capture free-blade bend profile once measured_
 
+## Reference images
+_TODO: add foot pocket reference photo_
+_TODO: add laminate stack photo_
+_TODO: add finished blade photo_
+
 ## Bill of Materials
 {{ render_technique_requirements_bill_of_materials() }}
 
 ## Tools Required
 {{ render_technique_requirements_tools() }}
-
-## Reference images
-_TODO: add foot pocket reference photo_
-_TODO: add laminate stack photo_
-_TODO: add finished blade photo_
 
 ## Instructions
 1. Build a 500 mm × 300 mm laminating base following [Creating a laminating base](../../../techniques/creating-laminating-base/v1/wood-support.md) so one blade can be laminated at a time.

--- a/docs/techniques/creating-laminating-base/v1/wood-support.md
+++ b/docs/techniques/creating-laminating-base/v1/wood-support.md
@@ -67,18 +67,18 @@ Create a rigid angled surface to support fin blades during lamination.
     - Minimum width: **25cm** (to match blade width).
     - Minimum length: **20cm** (to fit 15cm blade length and extra space).
 
+## Reference Images
+
+| ![Support Structure](support_all.jpeg) | ![Brackets and Side](support_brakets.jpeg) |
+|----------------------------------------|--------------------------------------------|
+| Full Support Structure                 | Brackets and Side Supports                 |
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
 
 ## Tools Required
 {{ render_tools_required() }}
-
-## Reference Images
-
-| ![Support Structure](support_all.jpeg) | ![Brackets and Side](support_brakets.jpeg) |
-|----------------------------------------|--------------------------------------------|
-| Full Support Structure                 | Brackets and Side Supports                 |
 
 ## Instructions (step-by-step)
 

--- a/docs/techniques/cutting-template/v1/paper-laminate.md
+++ b/docs/techniques/cutting-template/v1/paper-laminate.md
@@ -29,18 +29,18 @@ Produce a durable template that matches the foot pocket outline.
 ## Specifications / Dimensions
 - Sized to the chosen foot pocket and blade design
 
+## Reference Images
+
+| ![Paper Template](sf_paper_template.jpeg) | ![Cutting Template 1](sf_cutting_template_01.jpeg) | ![Cutting Template 2](sf_cutting_template_02.jpeg) |
+|-------------------------------------------|----------------------------------------------------|----------------------------------------------------
+| Paper Template Traced                     | Cutting Template Back                              | Cutting Template Front                                 
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
 
 ## Tools Required
 {{ render_tools_required() }}
-
-## Reference Images
-
-| ![Paper Template](sf_paper_template.jpeg) | ![Cutting Template 1](sf_cutting_template_01.jpeg) | ![Cutting Template 2](sf_cutting_template_02.jpeg) |
-|-------------------------------------------|----------------------------------------------------|----------------------------------------------------
-| Paper Template Traced                     | Cutting Template Back                              | Cutting Template Front                                 
 
 ## Instructions (step-by-step)
 1. **Print the Template**

--- a/docs/techniques/laminating-carbon/v1/wet-layup.md
+++ b/docs/techniques/laminating-carbon/v1/wet-layup.md
@@ -61,19 +61,18 @@ Produce a basic carbon blade using a manual wet layup.
 - Uses 0/90 3K twill carbon cloth
 - Geometry and taper follow the chosen cutting template
 
-## Bill of Materials
-
-{{ render_bill_of_materials() }}
-
-## Tools Required
-{{ render_tools_required() }}
-
 ## Reference Images
 
 | ![Wet Carbon Laminate](sf_laminate_wet.jpeg) | ![Cured Carbon Laminate  ](sf_laminate_cured.jpeg) |
 |-------------------------------------------|--------------------------------------------------|
 | Wet Carbon Laminate                       | Cured Carbon Laminate                       |
 
+## Bill of Materials
+
+{{ render_bill_of_materials() }}
+
+## Tools Required
+{{ render_tools_required() }}
 
 ## Instructions (step-by-step)
 

--- a/docs/techniques/measuring-flex/v2/kitchen-scale-test.md
+++ b/docs/techniques/measuring-flex/v2/kitchen-scale-test.md
@@ -12,18 +12,18 @@ tools_required:
 ## Goal
 Measure the load required to make the **tip vertical (90°)** and observe where the blade bends (root, mid, tip).
 
+## Reference Images
+
+|  | ![Kitchen Scale Test](t_kitchen_scale.jpeg) |  |
+|--|---------------------------------------------|--|
+|  | Kitchen Scale Test                          |  |
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
 
 ## Tools Required
 {{ render_tools_required() }}
-
-## Reference Images
-
-|  | ![Kitchen Scale Test](t_kitchen_scale.jpeg) |  |
-|--|---------------------------------------------|--|
-|  | Kitchen Scale Test                          |  |
 
 ## Instructions
 

--- a/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
@@ -32,17 +32,17 @@ To create a simple, low-cost vacuum environment for small parts using the manual
 - Pressure achievable: approximately -0.2 to -0.4 bar with a manual pump
 - Requires a flat, rigid base (e.g. acrylic sheet) to support the part
 
+## Reference Images
+
+|          | ![Full Bagging](full_bagging.jpeg) |          |
+|----------|------------------------------------|----------|
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}
 
 ## Tools Required
 {{ render_tools_required() }}
-
-## Reference Images
-
-|          | ![Full Bagging](full_bagging.jpeg) |          |
-|----------|------------------------------------|----------|
 
 ## Instructions (step-by-step)
 1. Smooth the edges of the base or part using the file to prevent puncturing the vacuum bag.


### PR DESCRIPTION
## Summary
- move the Reference Images sections ahead of the Bill of Materials sections for the short fins project and related techniques
- keep the surrounding Bill of Materials and Tools content intact while maintaining consistent spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe1f22014832c9ae581585a195ed7