### PR TITLE
Annotate materials with usage types

### DIFF
--- a/docs/materials/acrylic-sheet.md
+++ b/docs/materials/acrylic-sheet.md
@@ -1,6 +1,8 @@
 ---
 title: Acrylic Sheet
 material:
+  costing:
+    usage_type: reusable
   purchases:
     - supplier: "Amazon"
       url: "https://www.amazon.co.uk/dp/B09TL1SCCD"

--- a/docs/materials/bifin-footpockets.md
+++ b/docs/materials/bifin-footpockets.md
@@ -1,6 +1,8 @@
 ---
 title: Bifin Foot Pockets
 material:
+  costing:
+    usage_type: reusable
   purchases:
     - supplier: "AliExpress"
       url: "https://www.aliexpress.com/item/1005008784367959.html"

--- a/docs/materials/breather-cloth.md
+++ b/docs/materials/breather-cloth.md
@@ -1,6 +1,8 @@
 ---
 title: Breather Cloth
 material:
+  costing:
+    usage_type: consumable
   purchases:
     - supplier: "Easy Composites"
       url: "https://www.easycomposites.co.uk/breather-fabric"

--- a/docs/materials/butyl-sealing-tape.md
+++ b/docs/materials/butyl-sealing-tape.md
@@ -1,6 +1,8 @@
 ---
 title: Butyl Sealing Tape
 material:
+  costing:
+    usage_type: consumable
   purchases:
     - supplier: "Easy Composites"
       url: "https://www.easycomposites.co.uk/vacuum-bagging-sealant-tape"

--- a/docs/materials/carbon-fiber-fabric.md
+++ b/docs/materials/carbon-fiber-fabric.md
@@ -1,6 +1,8 @@
 ---
 title: Carbon Fiber Fabric
 material:
+  costing:
+    usage_type: consumable
   purchases:
     - supplier: "Easy Composites"
       url: "https://www.easycomposites.co.uk/200g-black-stuff-22-twill-3k-carbon-fibre-cloth"

--- a/docs/materials/clear-coat-spray.md
+++ b/docs/materials/clear-coat-spray.md
@@ -1,6 +1,8 @@
 ---
 title: Clear Coat Spray
 material:
+  costing:
+    usage_type: consumable
   purchases:
     - supplier: "Amazon"
       url: "https://www.amazon.co.uk/dp/B004SNLNY2"

--- a/docs/materials/index.md
+++ b/docs/materials/index.md
@@ -23,6 +23,57 @@ When new data comes in for other locales we can extend each page with additional
    correct record from the unit you supply. Quantities default to the chosen purchase unit, so you only need to describe
    the amount being used.
 
+## Usage types for the bill of materials
+
+Not every material behaves the same once it has been purchased. Resins, carbon
+cloth, and other supplies are consumed during a build, while acrylic base
+plates or footpockets stay in service for many projects. Rather than tracking
+per-build usage manually, classify each material with a simple `usage_type`
+flag so totals can be split into consumable spend versus reusable assets when a
+BOM is rendered.
+
+### 1. Declare the usage type on each material
+
+Add a `material.costing.usage_type` field to every material page. Use
+`consumable` for items that are spent during a build (the default if omitted)
+and `reusable` for tooling or hardware that comes back after the build.
+
+```yaml
+---
+title: PVA Release Agent
+material:
+  costing:
+    usage_type: consumable
+---
+```
+
+```yaml
+---
+title: Acrylic Base Plate
+material:
+  costing:
+    usage_type: reusable
+---
+```
+
+### 2. Let BOM entries inherit the usage type
+
+BOM items that reference a material page automatically take on that page's
+`usage_type`. If you need to describe a custom part that is not listed in the
+materials directory, set the flag directly on the BOM line so renderers can
+categorise it correctly:
+
+```yaml
+bill_of_materials:
+  - material: materials/pva-release-agent.md  # inherits `consumable`
+  - title: Custom jig
+    usage_type: reusable
+```
+
+This minimal metadata is enough for downstream tooling to distinguish
+consumable purchases from reusable kit without modelling amortisation or
+tracking build counts.
+
 Need a new material? Duplicate the template below.
 
 ```markdown

--- a/docs/materials/laminating-epoxy-system.md
+++ b/docs/materials/laminating-epoxy-system.md
@@ -1,6 +1,8 @@
 ---
 title: Laminating Epoxy System
 material:
+  costing:
+    usage_type: consumable
   purchases:
     - supplier: "Easy Composites"
       url: "https://www.easycomposites.co.uk/el2-epoxy-laminating-resin"

--- a/docs/materials/peel-ply.md
+++ b/docs/materials/peel-ply.md
@@ -1,6 +1,8 @@
 ---
 title: Peel Ply
 material:
+  costing:
+    usage_type: consumable
   purchases:
     - supplier: "Easy Composites"
       url: "https://www.easycomposites.co.uk/peel-ply"

--- a/docs/materials/plastic-to-carbon-adhesive.md
+++ b/docs/materials/plastic-to-carbon-adhesive.md
@@ -1,6 +1,8 @@
 ---
 title: Plastic to Carbon Adhesive
 material:
+  costing:
+    usage_type: consumable
   purchases:
     - supplier: "Amazon"
       url: "https://www.amazon.co.uk/dp/B01IBOK7FE"

--- a/docs/materials/pva-release-agent.md
+++ b/docs/materials/pva-release-agent.md
@@ -1,6 +1,8 @@
 ---
 title: PVA Release Agent
 material:
+  costing:
+    usage_type: consumable
   purchases:
     - supplier: "Easy Composites"
       url: "https://www.easycomposites.co.uk/pva-mould-release-agent"

--- a/docs/materials/rubber-fin-rails.md
+++ b/docs/materials/rubber-fin-rails.md
@@ -1,6 +1,8 @@
 ---
 title: Rubber Fin Rails
 material:
+  costing:
+    usage_type: consumable
   purchases:
     - supplier: "AliExpress"
       url: "https://www.aliexpress.com/item/1005007590033380.html"

--- a/docs/materials/stackable-plastic-wedges.md
+++ b/docs/materials/stackable-plastic-wedges.md
@@ -1,6 +1,8 @@
 ---
 title: Stackable Plastic Wedges
 material:
+  costing:
+    usage_type: reusable
   purchases:
     - supplier: "Amazon"
       url: "https://www.amazon.co.uk/dp/B0FC2GMBXH"

--- a/docs/materials/vacuum-bagging-kit.md
+++ b/docs/materials/vacuum-bagging-kit.md
@@ -1,6 +1,8 @@
 ---
 title: Vacuum Bagging Kit
 material:
+  costing:
+    usage_type: reusable
   purchases:
     - supplier: "Amazon"
       url: "https://www.amazon.co.uk/dp/B07RSCPH4N"


### PR DESCRIPTION
## Summary
- add a `material.costing.usage_type` flag to every material page so BOMs can separate consumables from reusable kit

## Testing
- mkdocs build -f mkdocs.local.yml --site-dir site

------
https://chatgpt.com/codex/tasks/task_e_68dbe79ecfd4832cb96790413930fac1