### PR TITLE
Surface BOM cost types in BOM tables

### DIFF
--- a/docs/css/bom-cost-label.css
+++ b/docs/css/bom-cost-label.css
@@ -1,0 +1,33 @@
+.bom-cost-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25em;
+    padding: 0.15em 0.5em;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    font: 500 10px/1.2 system-ui, sans-serif;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    background: #f2f4f8;
+    color: #4a5568;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+.bom-cost-label--consumable {
+    background: #fdeee0;
+    border-color: #f7c9a1;
+    color: #b6661d;
+}
+
+.bom-cost-label--reusable {
+    background: #e1f5ef;
+    border-color: #9fd9c6;
+    color: #2a7c66;
+}
+
+.bom-cost-label--custom {
+    background: #e7e9fb;
+    border-color: #b9c0f0;
+    color: #4c57a8;
+}

--- a/mkdocs.base.yml
+++ b/mkdocs.base.yml
@@ -39,6 +39,7 @@ extra:
 
 extra_css:
   - css/status-banner.css
+  - css/bom-cost-label.css
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary
- resolve each bill of materials item's usage type and carry it through rendering
- show the usage type as a color-coded label in the material description row
- add a stylesheet for the new labels and register it with MkDocs
- soften the label styling with a smaller size, border, and pastel palette

## Testing
- mkdocs build -f mkdocs.local.yml --site-dir site

------
https://chatgpt.com/codex/tasks/task_e_68dc1fa0b45c832cbc52150b92e3dabd