### PR TITLE
Add consumable scaling factor for project technique costs

### DIFF
--- a/docs/projects/short-fins/v1/power-fin.md
+++ b/docs/projects/short-fins/v1/power-fin.md
@@ -10,6 +10,7 @@ techniques:
   - title: Laminating Carbon
     focus: Creating the carbon laminate
     path: techniques/laminating-carbon/v1/wet-layup.md
+    consumable_scaling_factor: 2
   - title: Vacuum Bagging
     focus: Reducing the resin percentage of the laminate
     path: techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md


### PR DESCRIPTION
## Summary
- allow project technique references to include a consumable scaling factor
- scale consumable quantities and totals when rendering project technique bills of materials
- apply a scaling factor of 2 to the laminating-carbon technique in the short fins project

## Testing
- mkdocs build -f mkdocs.local.yml --site-dir site

------
https://chatgpt.com/codex/tasks/task_e_68dd7a83302c832cb67632a84164501b