### PR TITLE
Rework homepage hero and add projects overview

### DIFF
--- a/docs/assets/hero/neck-weight.svg
+++ b/docs/assets/hero/neck-weight.svg
@@ -1,0 +1,41 @@
+<svg width="420" height="320" viewBox="0 0 420 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="420" height="320" rx="32" fill="url(#bg)"/>
+  <g filter="url(#shadow)">
+    <path d="M210 68c56 0 102 42 102 94 0 26-12 50-34 66-24 18-54 26-68 26s-44-8-68-26c-22-16-34-40-34-66 0-52 46-94 102-94z" fill="url(#ring)"/>
+    <path d="M210 104c33 0 60 25 60 56 0 16-8 30-22 40-15 11-32 16-38 16s-23-5-38-16c-14-10-22-24-22-40 0-31 27-56 60-56z" fill="url(#inner)"/>
+    <path d="M210 132c16 0 30 12 30 28 0 8-4 15-10 20-7 5-14 8-20 8s-13-3-20-8c-6-5-10-12-10-20 0-16 14-28 30-28z" fill="#0E1632" opacity="0.35"/>
+    <path d="M210 68c-56 0-102 42-102 94 0 26 12 50 34 66 10 7 21 13 32 18-22-16-38-43-38-74 0-56 42-96 94-104z" fill="url(#shine)" opacity="0.65"/>
+    <path d="M270 44c10 0 20 6 24 16l14 32c5 12-5 24-18 24h-158c-13 0-23-12-18-24l14-32c4-10 14-16 24-16h118z" fill="url(#strap)"/>
+    <path d="M170 44c-12 0-22 8-26 18l-12 30c-4 10 4 22 16 22h24l10-70h-12z" fill="url(#strapHighlight)" opacity="0.5"/>
+    <rect x="186" y="36" width="48" height="24" rx="12" fill="#0E1632" opacity="0.6"/>
+  </g>
+  <defs>
+    <linearGradient id="bg" x1="60" y1="24" x2="360" y2="296" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#031122"/>
+      <stop offset="1" stop-color="#052646"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="122" y1="90" x2="298" y2="246" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFAF3D"/>
+      <stop offset="1" stop-color="#FF703D"/>
+    </linearGradient>
+    <linearGradient id="inner" x1="150" y1="140" x2="270" y2="230" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFD6A0"/>
+      <stop offset="1" stop-color="#FF9350"/>
+    </linearGradient>
+    <linearGradient id="shine" x1="120" y1="84" x2="200" y2="206" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFE4B8" stop-opacity="0.6"/>
+      <stop offset="1" stop-color="#FF9350" stop-opacity="0.2"/>
+    </linearGradient>
+    <linearGradient id="strap" x1="128" y1="44" x2="292" y2="132" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#323C6D"/>
+      <stop offset="1" stop-color="#1B2449"/>
+    </linearGradient>
+    <linearGradient id="strapHighlight" x1="144" y1="52" x2="204" y2="114" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6575A9"/>
+      <stop offset="1" stop-color="#1B2449" stop-opacity="0.2"/>
+    </linearGradient>
+    <filter id="shadow" x="64" y="24" width="292" height="260" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="20" stdDeviation="24" flood-color="#020914" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+</svg>

--- a/docs/assets/hero/nose-clip.svg
+++ b/docs/assets/hero/nose-clip.svg
@@ -1,0 +1,44 @@
+<svg width="420" height="320" viewBox="0 0 420 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="420" height="320" rx="32" fill="url(#bg)"/>
+  <g filter="url(#shadow)">
+    <path d="M190 70c10-18 36-18 46 0l76 138c10 18-2 40-23 40h-152c-21 0-33-22-23-40l76-138z" fill="url(#body)"/>
+    <path d="M210 88c4-8 16-8 20 0l62 112c5 8-1 20-10 20h-124c-9 0-15-12-10-20l62-112z" fill="url(#inner)"/>
+    <path d="M210 128c10 0 18 8 18 18v54c0 10-8 18-18 18s-18-8-18-18v-54c0-10 8-18 18-18z" fill="url(#bridge)"/>
+    <path d="M170 196c-10 0-20 4-27 11l-9 9c-9 9-24 9-33 0l-3-3c-9-9-9-24 0-33l37-37c9-9 24-9 33 0l2 2" stroke="url(#padLeft)" stroke-width="22" stroke-linecap="round"/>
+    <path d="M250 196c10 0 20 4 27 11l9 9c9 9 24 9 33 0l3-3c9-9 9-24 0-33l-37-37c-9-9-24-9-33 0l-2 2" stroke="url(#padRight)" stroke-width="22" stroke-linecap="round"/>
+    <path d="M210 88c-4-8-16-8-20 0l-62 112c-5 8 1 20 10 20h20l52-132z" fill="url(#shine)" opacity="0.55"/>
+  </g>
+  <defs>
+    <linearGradient id="bg" x1="52" y1="24" x2="368" y2="300" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#011428"/>
+      <stop offset="1" stop-color="#052B4A"/>
+    </linearGradient>
+    <linearGradient id="body" x1="118" y1="80" x2="302" y2="260" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#8D5BFF"/>
+      <stop offset="1" stop-color="#5230FF"/>
+    </linearGradient>
+    <linearGradient id="inner" x1="150" y1="112" x2="270" y2="248" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#C7B5FF"/>
+      <stop offset="1" stop-color="#6445FF"/>
+    </linearGradient>
+    <linearGradient id="bridge" x1="210" y1="128" x2="210" y2="218" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFE6FF"/>
+      <stop offset="1" stop-color="#C7B5FF"/>
+    </linearGradient>
+    <linearGradient id="padLeft" x1="120" y1="176" x2="168" y2="232" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF9E7A"/>
+      <stop offset="1" stop-color="#FF5D7A"/>
+    </linearGradient>
+    <linearGradient id="padRight" x1="252" y1="176" x2="300" y2="232" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF9E7A"/>
+      <stop offset="1" stop-color="#FF5D7A"/>
+    </linearGradient>
+    <linearGradient id="shine" x1="150" y1="110" x2="210" y2="210" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E4DAFF" stop-opacity="0.65"/>
+      <stop offset="1" stop-color="#6445FF" stop-opacity="0.25"/>
+    </linearGradient>
+    <filter id="shadow" x="62" y="40" width="296" height="252" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="22" stdDeviation="22" flood-color="#020914" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+</svg>

--- a/docs/assets/hero/short-fins.svg
+++ b/docs/assets/hero/short-fins.svg
@@ -1,0 +1,40 @@
+<svg width="480" height="360" viewBox="0 0 480 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="480" height="360" rx="36" fill="url(#bg)"/>
+  <g filter="url(#shadow)">
+    <path d="M146 90c32-6 66 6 88 30 24 26 26 65 12 96-15 35-51 58-89 63-30 3-66-8-88-32-22-23-27-54-18-83 11-36 41-68 85-74z" fill="url(#finBodyLeft)"/>
+    <path d="M334 90c32-6 66 6 88 30 24 26 26 65 12 96-15 35-51 58-89 63-30 3-66-8-88-32-22-23-27-54-18-83 11-36 41-68 85-74z" fill="url(#finBodyRight)"/>
+    <path d="M108 155c14-29 45-48 76-51l-6 122c-28-2-58-19-70-44-6-13-7-18 0-27z" fill="url(#bladeHighlight)" opacity="0.7"/>
+    <path d="M296 155c14-29 45-48 76-51l-6 122c-28-2-58-19-70-44-6-13-7-18 0-27z" fill="url(#bladeHighlight)" opacity="0.7"/>
+    <path d="M144 116c-6-19 7-42 28-50 16-7 36-3 48 10 15 17 12 39-10 54-18 12-53 9-66-14z" fill="#101731" opacity="0.65"/>
+    <path d="M332 116c-6-19 7-42 28-50 16-7 36-3 48 10 15 17 12 39-10 54-18 12-53 9-66-14z" fill="#101731" opacity="0.65"/>
+    <path d="M148 122c14-2 25 3 32 13 8 11 7 25 1 39-8 17-24 30-40 32-13 2-27-2-36-12-9-9-11-24-6-36 6-17 21-33 49-36z" fill="url(#footPocket)"/>
+    <path d="M336 122c14-2 25 3 32 13 8 11 7 25 1 39-8 17-24 30-40 32-13 2-27-2-36-12-9-9-11-24-6-36 6-17 21-33 49-36z" fill="url(#footPocket)"/>
+    <path d="M128 182c25 9 47 9 68 0" stroke="#76D5FF" stroke-width="6" stroke-linecap="round" opacity="0.7"/>
+    <path d="M316 182c25 9 47 9 68 0" stroke="#76D5FF" stroke-width="6" stroke-linecap="round" opacity="0.7"/>
+  </g>
+  <defs>
+    <linearGradient id="bg" x1="48" y1="36" x2="432" y2="324" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D1A40"/>
+      <stop offset="1" stop-color="#172B65"/>
+    </linearGradient>
+    <linearGradient id="finBodyLeft" x1="76" y1="90" x2="266" y2="287" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4CC7FF"/>
+      <stop offset="1" stop-color="#1F68FF"/>
+    </linearGradient>
+    <linearGradient id="finBodyRight" x1="264" y1="90" x2="454" y2="287" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4CC7FF"/>
+      <stop offset="1" stop-color="#1F68FF"/>
+    </linearGradient>
+    <linearGradient id="bladeHighlight" x1="96" y1="140" x2="202" y2="260" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#99E5FF" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="#1F68FF" stop-opacity="0.3"/>
+    </linearGradient>
+    <linearGradient id="footPocket" x1="128" y1="128" x2="204" y2="212" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1A2A50"/>
+      <stop offset="1" stop-color="#0E1632"/>
+    </linearGradient>
+    <filter id="shadow" x="60" y="56" width="360" height="260" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="24" stdDeviation="24" flood-color="#020914" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+</svg>

--- a/docs/css/hero-home.css
+++ b/docs/css/hero-home.css
@@ -1,7 +1,8 @@
 .hero-home {
+  --hero-price-color: #f59e0b;
   display: flex;
   flex-direction: column;
-  gap: 3rem;
+  gap: 2.5rem;
 }
 
 .hero-intro {
@@ -13,13 +14,13 @@
 
 .hero-intro h1 {
   margin: 0;
-  font-size: clamp(2.5rem, 3vw + 1.5rem, 4rem);
-  line-height: 1.02;
+  font-size: clamp(2.1rem, 2.4vw + 1.4rem, 3.4rem);
+  line-height: 1.05;
 }
 
 .hero-subtitle {
   margin: 0;
-  font-size: clamp(1.25rem, 1.5vw + 1rem, 1.75rem);
+  font-size: clamp(1.05rem, 1.1vw + 0.95rem, 1.5rem);
   color: var(--md-default-fg-color--light, rgba(17, 24, 39, 0.72));
 }
 
@@ -30,9 +31,9 @@
 
 .hero-shield {
   display: grid;
-  gap: 1.25rem;
+  gap: 1rem;
   align-items: center;
-  padding: clamp(1.5rem, 1.5vw + 1rem, 2.25rem);
+  padding: clamp(1.5rem, 1.3vw + 0.9rem, 2rem);
   border-radius: 28px;
   background: linear-gradient(145deg, rgba(45, 102, 246, 0.12), rgba(45, 207, 246, 0.16));
   box-shadow: 0 24px 48px rgba(13, 26, 64, 0.14);
@@ -40,7 +41,7 @@
 }
 
 .hero-shield img {
-  width: min(220px, 40vw);
+  width: min(260px, 55vw);
   height: auto;
   justify-self: center;
 }
@@ -48,19 +49,19 @@
 .hero-shield__body {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
   text-align: center;
 }
 
 .hero-shield__body h2 {
   margin: 0;
-  font-size: clamp(1.6rem, 1.2vw + 1.25rem, 2.1rem);
+  font-size: clamp(1.35rem, 1vw + 1.1rem, 1.8rem);
 }
 
 .hero-shield__price {
   margin: 0;
   font-weight: 600;
-  color: var(--md-primary-fg-color);
+  color: var(--hero-price-color);
 }
 
 .hero-shield__link {
@@ -79,7 +80,7 @@
 
 .hero-projects-cta p {
   margin: 0;
-  font-size: 1.05rem;
+  font-size: 1rem;
   color: var(--md-default-fg-color--light, rgba(17, 24, 39, 0.7));
 }
 

--- a/docs/css/hero-home.css
+++ b/docs/css/hero-home.css
@@ -2,38 +2,38 @@
   --hero-price-color: #f59e0b;
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 1.75rem;
 }
 
 .hero-intro {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
   text-align: center;
 }
 
 .hero-intro h1 {
   margin: 0;
-  font-size: clamp(2.1rem, 2.4vw + 1.4rem, 3.4rem);
+  font-size: clamp(1.9rem, 2vw + 1.2rem, 2.8rem);
   line-height: 1.05;
 }
 
 .hero-subtitle {
   margin: 0;
-  font-size: clamp(1.05rem, 1.1vw + 0.95rem, 1.5rem);
+  font-size: clamp(0.95rem, 0.9vw + 0.85rem, 1.3rem);
   color: var(--md-default-fg-color--light, rgba(17, 24, 39, 0.72));
 }
 
 .hero-shields {
   display: grid;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .hero-shield {
   display: grid;
-  gap: 1rem;
+  gap: 0.75rem;
   align-items: center;
-  padding: clamp(1.5rem, 1.3vw + 0.9rem, 2rem);
+  padding: clamp(1.25rem, 1vw + 0.8rem, 1.75rem);
   border-radius: 28px;
   background: linear-gradient(145deg, rgba(45, 102, 246, 0.12), rgba(45, 207, 246, 0.16));
   box-shadow: 0 24px 48px rgba(13, 26, 64, 0.14);
@@ -49,13 +49,13 @@
 .hero-shield__body {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4rem;
   text-align: center;
 }
 
 .hero-shield__body h2 {
   margin: 0;
-  font-size: clamp(1.35rem, 1vw + 1.1rem, 1.8rem);
+  font-size: clamp(1.2rem, 0.8vw + 1rem, 1.6rem);
 }
 
 .hero-shield__price {
@@ -71,11 +71,11 @@
 
 .hero-projects-cta {
   display: grid;
-  gap: 0.5rem;
+  gap: 0.4rem;
   text-align: center;
   background: rgba(13, 26, 64, 0.04);
   border-radius: 24px;
-  padding: 1.5rem;
+  padding: 1.25rem;
 }
 
 .hero-projects-cta p {

--- a/docs/css/hero-home.css
+++ b/docs/css/hero-home.css
@@ -1,0 +1,116 @@
+.hero-home {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.hero-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.hero-intro h1 {
+  margin: 0;
+  font-size: clamp(2.5rem, 3vw + 1.5rem, 4rem);
+  line-height: 1.02;
+}
+
+.hero-subtitle {
+  margin: 0;
+  font-size: clamp(1.25rem, 1.5vw + 1rem, 1.75rem);
+  color: var(--md-default-fg-color--light, rgba(17, 24, 39, 0.72));
+}
+
+.hero-shields {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero-shield {
+  display: grid;
+  gap: 1.25rem;
+  align-items: center;
+  padding: clamp(1.5rem, 1.5vw + 1rem, 2.25rem);
+  border-radius: 28px;
+  background: linear-gradient(145deg, rgba(45, 102, 246, 0.12), rgba(45, 207, 246, 0.16));
+  box-shadow: 0 24px 48px rgba(13, 26, 64, 0.14);
+  border: 1px solid rgba(45, 102, 246, 0.1);
+}
+
+.hero-shield img {
+  width: min(220px, 40vw);
+  height: auto;
+  justify-self: center;
+}
+
+.hero-shield__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.hero-shield__body h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 1.2vw + 1.25rem, 2.1rem);
+}
+
+.hero-shield__price {
+  margin: 0;
+  font-weight: 600;
+  color: var(--md-primary-fg-color);
+}
+
+.hero-shield__link {
+  font-weight: 600;
+  color: var(--md-primary-fg-color);
+}
+
+.hero-projects-cta {
+  display: grid;
+  gap: 0.5rem;
+  text-align: center;
+  background: rgba(13, 26, 64, 0.04);
+  border-radius: 24px;
+  padding: 1.5rem;
+}
+
+.hero-projects-cta p {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--md-default-fg-color--light, rgba(17, 24, 39, 0.7));
+}
+
+.hero-projects-cta__link {
+  font-weight: 600;
+  color: var(--md-primary-fg-color);
+}
+
+@media (min-width: 900px) {
+  .hero-intro {
+    text-align: left;
+    align-items: flex-start;
+  }
+
+  .hero-shields {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .hero-shield {
+    grid-template-rows: auto 1fr;
+    text-align: left;
+  }
+
+  .hero-shield__body {
+    text-align: left;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero-shield {
+    border-radius: 22px;
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,47 @@
-# ApneaScrap Lab
-DIY freediving gear — project versions and results.
+---
+title: ApneaScrap Lab
+hide:
+  - navigation
+  - toc
+---
 
-- [🤿 **Short fins**](projects/short-fins/index.md)
-- [🏋️ **Neck weight**](projects/neck-weight/index.md)
-- [🧪 **Future gear**](projects/future-gear/index.md)
+<div class="hero-home">
+  <section class="hero-intro">
+    <h1>DIY freediving gear.</h1>
+    <p class="hero-subtitle">Level up your freediving gear on the cheap.</p>
+  </section>
+
+  <section class="hero-shields" aria-label="Featured projects">
+    <article class="hero-shield">
+      <img src="assets/hero/short-fins.svg" alt="Illustration of the compress short fins project" loading="lazy" />
+      <div class="hero-shield__body">
+        <h2>Compress short fins</h2>
+        <p class="hero-shield__price">Materials: about $95 per pair</p>
+        <a class="hero-shield__link" href="projects/short-fins/index.md">Build the short fins &rarr;</a>
+      </div>
+    </article>
+
+    <article class="hero-shield">
+      <img src="assets/hero/neck-weight.svg" alt="Illustration of the modular neck weight" loading="lazy" />
+      <div class="hero-shield__body">
+        <h2>Modular neck weight</h2>
+        <p class="hero-shield__price">Materials: about $18 per weight</p>
+        <a class="hero-shield__link" href="projects/neck-weight/index.md">Pour a balanced weight &rarr;</a>
+      </div>
+    </article>
+
+    <article class="hero-shield">
+      <img src="assets/hero/nose-clip.svg" alt="Illustration of the low-profile nose clip" loading="lazy" />
+      <div class="hero-shield__body">
+        <h2>Low-profile nose clip</h2>
+        <p class="hero-shield__price">Materials: about $6 per clip</p>
+        <a class="hero-shield__link" href="projects/future-gear/index.md#nose-clip-prototype">Follow the prototype &rarr;</a>
+      </div>
+    </article>
+  </section>
+
+  <section class="hero-projects-cta">
+    <p>Ready for more? Dive into every iteration we have documented so far.</p>
+    <a class="hero-projects-cta__link" href="projects/index.md">Browse all projects &rarr;</a>
+  </section>
+</div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@ hide:
 
 <div class="hero-home">
   <section class="hero-intro">
-    <h1>DIY freediving gear.</h1>
-    <p class="hero-subtitle">Level up your freediving gear on the cheap.</p>
+    <h1>DIY freediving gear</h1>
+    <p class="hero-subtitle">Level up your freediving gear on the cheap</p>
   </section>
 
   <section class="hero-shields" aria-label="Featured projects">
@@ -41,7 +41,7 @@ hide:
   </section>
 
   <section class="hero-projects-cta">
-    <p>Ready for more? Dive into every iteration we have documented so far.</p>
+    <p>Ready for more? Dive into every iteration we have documented so far</p>
     <a class="hero-projects-cta__link" href="projects/index.md">Browse all projects &rarr;</a>
   </section>
 </div>

--- a/docs/projects/future-gear/index.md
+++ b/docs/projects/future-gear/index.md
@@ -1,6 +1,12 @@
 # Future gear
+
 Placeholder for upcoming projects.
 
 - Medium fins
 - Long fins
 - Monofin
+
+## Nose clip prototype
+
+Lightweight squeeze control concept that pairs printed carbon-filled arms with silicone pads. Notes will land here as the geometry testing wraps up.
+

--- a/docs/projects/index.md
+++ b/docs/projects/index.md
@@ -1,0 +1,12 @@
+# Projects
+
+Explore every build we are documenting in the lab. Each project index collects the current version notes, BOM, and testing logs so you can replicate or remix the work.
+
+## Short fins
+- [Short fins versions](short-fins/index.md): laminated blades tuned for pool dynamics with compress layups and flex measurements.
+
+## Neck weight
+- [Neck weight versions](neck-weight/index.md): modular ballast systems with molded sleeves and quick-adjust ballast pods.
+
+## Future gear
+- [(Future gear) experiments](future-gear/index.md): prototypes that are being sketched, tested, and refined before they graduate into full projects.

--- a/mkdocs.base.yml
+++ b/mkdocs.base.yml
@@ -40,10 +40,12 @@ extra:
 extra_css:
   - css/status-banner.css
   - css/bom-cost-label.css
+  - css/hero-home.css
 
 nav:
   - Home: index.md
   - Projects:
+      - Projects Overview: projects/index.md
       - Short Fins:
           - Short Fins Versions: projects/short-fins/index.md
           - V1 - Power Fin: projects/short-fins/v1/power-fin.md


### PR DESCRIPTION
## Summary
- hide the left-hand navigation on the home page so the hero layout is distraction free
- redesign the homepage hero into three project shields with cost callouts and a link to the full projects catalog
- add a projects overview index page and link it from the navigation

## Testing
- mkdocs build -f mkdocs.local.yml --site-dir site

------
https://chatgpt.com/codex/tasks/task_e_68ddad62546c832cb6d661002988f243