### PR TITLE
Add macros to surface implementation timing

### DIFF
--- a/docs/projects/neck-weight/v1-shot-inner-tube.md
+++ b/docs/projects/neck-weight/v1-shot-inner-tube.md
@@ -12,4 +12,7 @@ waiting_time: 0
 ---
 # Neck weight v1 — shot in inner tube
 {{ status_banner() }}
+
+{{ render_project_time_breakdown() }}
+
 Cheap, tool‑light build; sleeve the tube for safety.

--- a/docs/projects/neck-weight/v2-molded-sleeve.md
+++ b/docs/projects/neck-weight/v2-molded-sleeve.md
@@ -12,4 +12,7 @@ waiting_time: 12
 ---
 # Neck weight v2 — molded sleeve
 {{ status_banner() }}
+
+{{ render_project_time_breakdown() }}
+
 Encapsulated core, smooth finish, front quick‑release.

--- a/docs/projects/short-fins/v1/power-fin.md
+++ b/docs/projects/short-fins/v1/power-fin.md
@@ -30,6 +30,8 @@ techniques:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_project_time_breakdown() }}
+
 Compact training fins, somewhat hard flex but with a small surface.
 
 ## Planning

--- a/docs/techniques/creating-laminating-base/v1/wood-support.md
+++ b/docs/techniques/creating-laminating-base/v1/wood-support.md
@@ -52,6 +52,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_technique_time_overview() }}
+
 25° wooden base with acrylic sheets for laminating carbon fin blades.
 
 ## Goal

--- a/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
+++ b/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
@@ -43,6 +43,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_technique_time_overview() }}
+
 This document describes how to build a modular acrylic base with wedge supports for laminating carbon fins.
 The example shown is for a **70 × 70 cm monofin**, but the same technique can be adapted for **bifins** or other blade sizes.
 

--- a/docs/techniques/cutting-cured-carbon/v1/junior-hacksaw.md
+++ b/docs/techniques/cutting-cured-carbon/v1/junior-hacksaw.md
@@ -17,6 +17,8 @@ tools_required:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_technique_time_overview() }}
+
 ## Goal
 To cut cured carbon laminate into the desired shape using a simple junior hacksaw method, ensuring a clean fit into the final assembly.
 

--- a/docs/techniques/cutting-template/v1/paper-laminate.md
+++ b/docs/techniques/cutting-template/v1/paper-laminate.md
@@ -21,6 +21,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_technique_time_overview() }}
+
 This technique shows how to create a cutting template for fins using laminated paper.
 
 ## Goal

--- a/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
+++ b/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
@@ -45,6 +45,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_technique_time_overview() }}
+
 ## Goal
 
 To apply a protective and aesthetic finish to cured carbon blades by sealing, smoothing, and clear-coating the surface.

--- a/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
+++ b/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
@@ -31,6 +31,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_technique_time_overview() }}
+
 ## Goal
 
 To attach rubber fin rails securely to carbon fiber blades using a strong composite adhesive.

--- a/docs/techniques/laminating-carbon/v1/wet-layup.md
+++ b/docs/techniques/laminating-carbon/v1/wet-layup.md
@@ -52,6 +52,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_technique_time_overview() }}
+
 Baseline recipe with 0/90 twill and simple taper.
 
 ## Goal

--- a/docs/techniques/measuring-flex/v1/weight-belt-test.md
+++ b/docs/techniques/measuring-flex/v1/weight-belt-test.md
@@ -35,6 +35,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_technique_time_overview() }}
+
 ## Goal
 Measure the load required to make the **tip vertical (90°)** and observe where the blade bends (root, mid, tip).
 

--- a/docs/techniques/measuring-flex/v2/kitchen-scale-test.md
+++ b/docs/techniques/measuring-flex/v2/kitchen-scale-test.md
@@ -9,6 +9,8 @@ tools_required:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_technique_time_overview() }}
+
 ## Goal
 Measure the load required to make the **tip vertical (90°)** and observe where the blade bends (root, mid, tip).
 

--- a/docs/techniques/measuring-vacuum/v1/syringe-gauge.md
+++ b/docs/techniques/measuring-vacuum/v1/syringe-gauge.md
@@ -28,6 +28,8 @@ bill_of_materials:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_technique_time_overview() }}
+
 A simple gauge to monitor mild vacuum (~81 kPa absolute, −20 kPa gauge) directly **inside** a vacuum bag.
 It uses Boyle’s law: trapped air expands as pressure drops, moving a rubber plunger seal you can read through the bag.
 

--- a/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
@@ -23,6 +23,8 @@ tools_required:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_technique_time_overview() }}
+
 ## Goal
 To create a simple, low-cost vacuum environment for small parts using the manual pump and storage bags from the vacuum bagging kit.
 

--- a/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
@@ -37,6 +37,8 @@ tools_required:
 # {{ parent_child_title() }}
 {{ status_banner() }}
 
+{{ render_technique_time_overview() }}
+
 ## Goal
 To enable vacuum bagging of larger parts by sealing a cut vacuum bag directly to the laminating base using butyl tape, while achieving a controlled and measurable vacuum level.
 

--- a/main.py
+++ b/main.py
@@ -32,6 +32,23 @@ def define_env(env):
             text = text.rstrip("0").rstrip(".")
         return text
 
+    def _coerce_decimal(value) -> Decimal | None:
+        if value is None:
+            return None
+
+        if isinstance(value, Decimal):
+            return value
+
+        try:
+            return Decimal(str(value))
+        except Exception:
+            return None
+
+    def _format_hours_display(value: Decimal | None) -> str:
+        if value is None:
+            return ""
+        return f"{_format_decimal(value)} h"
+
     def _format_currency(amount: Decimal, currency: str) -> str:
         currency = (currency or "").upper()
         symbols = {
@@ -251,6 +268,57 @@ def define_env(env):
             )
 
         return resolved
+
+    def _calculate_time_summary(meta_source: Path) -> dict:
+        meta = read_meta(meta_source)
+        implementation_meta = _coerce_decimal(meta.get("time_to_implement"))
+        waiting_meta = _coerce_decimal(meta.get("waiting_time"))
+
+        techniques = _resolve_project_techniques(meta_source)
+        breakdown: list[dict] = []
+        total_impl = Decimal("0")
+        total_wait = Decimal("0")
+        has_impl = False
+        has_wait = False
+
+        for technique in techniques:
+            technique_meta = read_meta(technique["path"])
+            technique_impl = _coerce_decimal(technique_meta.get("time_to_implement"))
+            technique_wait = _coerce_decimal(technique_meta.get("waiting_time"))
+            scale_factor: Decimal = technique.get("consumable_scale_factor") or Decimal("1")
+
+            scaled_impl: Decimal | None = None
+            if technique_impl is not None:
+                scaled_impl = technique_impl * scale_factor
+                total_impl += scaled_impl
+                has_impl = True
+
+            scaled_wait: Decimal | None = None
+            if technique_wait is not None:
+                scaled_wait = technique_wait * scale_factor
+                total_wait += scaled_wait
+                has_wait = True
+
+            breakdown.append(
+                {
+                    "technique": technique,
+                    "implementation": scaled_impl,
+                    "waiting": scaled_wait,
+                }
+            )
+
+        computed_impl = total_impl if has_impl else None
+        computed_wait = total_wait if has_wait else None
+
+        return {
+            "implementation": implementation_meta if implementation_meta is not None else computed_impl,
+            "waiting": waiting_meta if waiting_meta is not None else computed_wait,
+            "breakdown": breakdown,
+            "computed": {
+                "implementation": computed_impl,
+                "waiting": computed_wait,
+            },
+        }
 
     def _prepare_technique_requirement_items(
         source_items: list[dict], factor: Decimal | None
@@ -792,8 +860,9 @@ def define_env(env):
                     if aggregated_items:
                         bom_items = aggregated_items
 
-            impl = meta.get("time_to_implement")
-            wait = meta.get("waiting_time")
+            summary = _calculate_time_summary(file)
+            impl_display = _format_hours_display(summary.get("implementation"))
+            wait_display = _format_hours_display(summary.get("waiting"))
             status = meta.get("status", "")
             if status:
                 status_class = status.lower().replace(" ", "-")
@@ -886,8 +955,8 @@ def define_env(env):
                     status_html,
                     cost_consumable_display,
                     cost_reusable_display,
-                    f"{impl}h" if impl is not None else "",
-                    f"{wait}h" if wait is not None else "",
+                    impl_display,
+                    wait_display,
                 )
             )
 
@@ -895,7 +964,7 @@ def define_env(env):
             return "No versions documented yet."
 
         header = (
-            "| Version | Status | Consumable Cost | Reusable Cost | Implementation Time (h) | Waiting Time (h) |"
+            "| Version | Status | Consumable Cost | Reusable Cost | Implementation Time | Waiting Time |"
         )
         separator = "|---|---|---|---|---|---|"
         lines = [header, separator]
@@ -1169,6 +1238,70 @@ def define_env(env):
             return ""
         escaped = escape(value)
         return escaped.replace("|", "&#124;").replace("\n", "<br>")
+
+    @env.macro
+    def render_technique_time_overview(path: str | None = None) -> str:
+        meta_source = Path(path) if path else Path(env.page.file.abs_src_path)
+        summary = _calculate_time_summary(meta_source)
+
+        implementation_display = _format_hours_display(summary.get("implementation"))
+        waiting_display = _format_hours_display(summary.get("waiting"))
+
+        if not implementation_display and not waiting_display:
+            return "No time estimates recorded yet."
+
+        header = "| Type | Hours |"
+        separator = "|---|---|"
+        rows = [
+            f"| Implementation | {implementation_display} |",
+            f"| Waiting | {waiting_display} |",
+        ]
+        return "\n".join([header, separator, *rows])
+
+    @env.macro
+    def render_project_time_breakdown(path: str | None = None) -> str:
+        meta_source = Path(path) if path else Path(env.page.file.abs_src_path)
+        summary = _calculate_time_summary(meta_source)
+        breakdown = summary.get("breakdown", [])
+
+        if not breakdown:
+            return render_technique_time_overview(path)
+
+        header = "| Technique | Implementation | Waiting |"
+        separator = "|---|---|---|"
+        lines = [header, separator]
+
+        for entry in breakdown:
+            technique = entry["technique"]
+            label_parts = [_format_table_cell(str(technique.get("title") or ""))]
+
+            notes_value = technique.get("notes")
+            if notes_value:
+                notes_html = _format_table_cell(str(notes_value))
+                if notes_html:
+                    label_parts.append(f"<small><em>{notes_html}</em></small>")
+
+            scale_factor = technique.get("consumable_scale_factor")
+            if scale_factor and scale_factor != Decimal("1"):
+                label_parts.append(f"<small>×{_format_decimal(scale_factor)}</small>")
+
+            label = "<br>".join(part for part in label_parts if part)
+            implementation_display = _format_hours_display(entry.get("implementation"))
+            waiting_display = _format_hours_display(entry.get("waiting"))
+
+            lines.append(
+                f"| {label} | {implementation_display} | {waiting_display} |"
+            )
+
+        totals = summary.get("computed", {})
+        total_impl_display = _format_hours_display(totals.get("implementation"))
+        total_wait_display = _format_hours_display(totals.get("waiting"))
+        if total_impl_display or total_wait_display:
+            impl_cell = f"**{total_impl_display}**" if total_impl_display else ""
+            wait_cell = f"**{total_wait_display}**" if total_wait_display else ""
+            lines.append(f"| **Total** | {impl_cell} | {wait_cell} |")
+
+        return "\n".join(lines)
 
     @env.macro
     def render_bill_of_materials(path: str | None = None) -> str:


### PR DESCRIPTION
## Summary
- add helpers and macros to calculate implementation and waiting time for techniques and projects
- render the time overview tables across technique and project documentation pages
- reuse the shared logic when filling in implementation and waiting time in the versions table

## Testing
- mkdocs build -f mkdocs.local.yml --site-dir site

------
https://chatgpt.com/codex/tasks/task_e_68e4295db220832c83b11cf12fe03deb