### PR TITLE
Adjust time tables and placement

### DIFF
--- a/docs/projects/neck-weight/v1-shot-inner-tube.md
+++ b/docs/projects/neck-weight/v1-shot-inner-tube.md
@@ -12,4 +12,9 @@ waiting_time: 0
 ---
 # Neck weight v1 — shot in inner tube
 {{ status_banner() }}
+
+## Time needed
+
+{{ render_project_time_breakdown() }}
+
 Cheap, tool‑light build; sleeve the tube for safety.

--- a/docs/projects/neck-weight/v2-molded-sleeve.md
+++ b/docs/projects/neck-weight/v2-molded-sleeve.md
@@ -12,4 +12,9 @@ waiting_time: 12
 ---
 # Neck weight v2 — molded sleeve
 {{ status_banner() }}
+
+## Time needed
+
+{{ render_project_time_breakdown() }}
+
 Encapsulated core, smooth finish, front quick‑release.

--- a/docs/projects/short-fins/v1/power-fin.md
+++ b/docs/projects/short-fins/v1/power-fin.md
@@ -92,6 +92,10 @@ Predicted:
 | Complete fins                   | Nice and compact              |
 
 
+## Time needed
+
+{{ render_project_time_breakdown() }}
+
 ## Bill of Materials
 {{ render_technique_requirements_bill_of_materials() }}
 

--- a/docs/techniques/creating-laminating-base/v1/wood-support.md
+++ b/docs/techniques/creating-laminating-base/v1/wood-support.md
@@ -75,6 +75,10 @@ Create a rigid angled surface to support fin blades during lamination.
 |----------------------------------------|--------------------------------------------|
 | Full Support Structure                 | Brackets and Side Supports                 |
 
+## Time needed
+
+{{ render_technique_time_overview() }}
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}

--- a/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
+++ b/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
@@ -55,6 +55,10 @@ Provide a modular surface with adjustable wedges to support blades during lamina
 - **Support requirement:** Must be placed on a **flat, rigid surface** such as a table or workbench  
 - **Protection:** Place a **plastic sheet** under the base to protect the table surface  
 
+## Time needed
+
+{{ render_technique_time_overview() }}
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}

--- a/docs/techniques/cutting-cured-carbon/v1/junior-hacksaw.md
+++ b/docs/techniques/cutting-cured-carbon/v1/junior-hacksaw.md
@@ -20,6 +20,10 @@ tools_required:
 ## Goal
 To cut cured carbon laminate into the desired shape using a simple junior hacksaw method, ensuring a clean fit into the final assembly.
 
+## Time needed
+
+{{ render_technique_time_overview() }}
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}

--- a/docs/techniques/cutting-template/v1/paper-laminate.md
+++ b/docs/techniques/cutting-template/v1/paper-laminate.md
@@ -35,6 +35,10 @@ Produce a durable template that matches the foot pocket outline.
 |-------------------------------------------|----------------------------------------------------|----------------------------------------------------
 | Paper Template Traced                     | Cutting Template Back                              | Cutting Template Front                                 
 
+## Time needed
+
+{{ render_technique_time_overview() }}
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}

--- a/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
+++ b/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
@@ -50,6 +50,10 @@ bill_of_materials:
 To apply a protective and aesthetic finish to cured carbon blades by sealing, smoothing, and clear-coating the surface.
 This improves durability, protects against moisture, enhances gloss, and provides the option for custom decals.
 
+## Time needed
+
+{{ render_technique_time_overview() }}
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}

--- a/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
+++ b/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
@@ -36,6 +36,10 @@ bill_of_materials:
 To attach rubber fin rails securely to carbon fiber blades using a strong composite adhesive.
 The rails protect the blade edges, improve water flow, and extend the blade’s lifespan.
 
+## Time needed
+
+{{ render_technique_time_overview() }}
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}

--- a/docs/techniques/laminating-carbon/v1/wet-layup.md
+++ b/docs/techniques/laminating-carbon/v1/wet-layup.md
@@ -67,6 +67,10 @@ Produce a basic carbon blade using a manual wet layup.
 |-------------------------------------------|--------------------------------------------------|
 | Wet Carbon Laminate                       | Cured Carbon Laminate                       |
 
+## Time needed
+
+{{ render_technique_time_overview() }}
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}

--- a/docs/techniques/measuring-flex/v1/weight-belt-test.md
+++ b/docs/techniques/measuring-flex/v1/weight-belt-test.md
@@ -43,6 +43,10 @@ Measure the load required to make the **tip vertical (90°)** and observe where 
 - Marks at 0.3 L (root), 0.6 L (mid), and 0.9 L (tip)
 - Weights applied in a 2:1 ratio (tip:mid)
 
+## Time needed
+
+{{ render_technique_time_overview() }}
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}

--- a/docs/techniques/measuring-flex/v2/kitchen-scale-test.md
+++ b/docs/techniques/measuring-flex/v2/kitchen-scale-test.md
@@ -18,6 +18,10 @@ Measure the load required to make the **tip vertical (90°)** and observe where 
 |--|---------------------------------------------|--|
 |  | Kitchen Scale Test                          |  |
 
+## Time needed
+
+{{ render_technique_time_overview() }}
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}

--- a/docs/techniques/measuring-vacuum/v1/syringe-gauge.md
+++ b/docs/techniques/measuring-vacuum/v1/syringe-gauge.md
@@ -34,6 +34,10 @@ It uses Boyle’s law: trapped air expands as pressure drops, moving a rubber pl
 ## Goal
 Monitor vacuum level inside a bag using plunger movement.
 
+## Time needed
+
+{{ render_technique_time_overview() }}
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}

--- a/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
@@ -37,6 +37,10 @@ To create a simple, low-cost vacuum environment for small parts using the manual
 |          | ![Full Bagging](full_bagging.jpeg) |          |
 |----------|------------------------------------|----------|
 
+## Time needed
+
+{{ render_technique_time_overview() }}
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}

--- a/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
@@ -45,6 +45,10 @@ To enable vacuum bagging of larger parts by sealing a cut vacuum bag directly to
 - Target vacuum level: ~80% vacuum (-0.2 bar relative to atmosphere)
 - Requires a rigid, smooth laminating base for edge sealing
 
+## Time needed
+
+{{ render_technique_time_overview() }}
+
 ## Bill of Materials
 
 {{ render_bill_of_materials() }}


### PR DESCRIPTION
## Summary
- add helpers and macros to calculate implementation and waiting time for techniques and projects
- render the time overview tables across technique and project documentation pages
- reuse the shared logic when filling in implementation and waiting time in the versions table
- stop scaling project time summaries by consumable factors and move the time tables to dedicated "Time needed" sections before each bill of materials

## Testing
- mkdocs build -f mkdocs.local.yml --site-dir site

------
https://chatgpt.com/codex/tasks/task_e_68e4295db220832c83b11cf12fe03deb