### PR TITLE
Update status badges to proven/concept/legacy scheme

### DIFF
--- a/docs/css/status-banner.css
+++ b/docs/css/status-banner.css
@@ -19,9 +19,9 @@
     text-align: center;
 }
 
-.status-banner.status-active,
-.status-badge.status-active { background: #2e7d32; }
-.status-banner.status-research,
-.status-badge.status-research { background: #0277bd; }
-.status-banner.status-superseded,
-.status-badge.status-superseded { background: #cb0f0f; }
+.status-banner.status-proven,
+.status-badge.status-proven { background: #2ecc71; }
+.status-banner.status-concept,
+.status-badge.status-concept { background: #3498db; }
+.status-banner.status-legacy,
+.status-badge.status-legacy { background: #f39c12; }

--- a/docs/css/status-banner.css
+++ b/docs/css/status-banner.css
@@ -1,5 +1,4 @@
-.status-banner,
-.status-badge {
+.status-banner {
     color: #fff;
     background: #555;
 }
@@ -11,17 +10,6 @@
     margin-bottom: 1em;
 }
 
-.status-badge {
-    display: inline-block;
-    padding: 4px 10px;
-    font: 500 12px/1.2 system-ui, sans-serif;
-    border-radius: 999px;
-    text-align: center;
-}
-
-.status-banner.status-proven,
-.status-badge.status-proven { background: #2e7d32; }
-.status-banner.status-concept,
-.status-badge.status-concept { background: #0277bd; }
-.status-banner.status-legacy,
-.status-badge.status-legacy { background: #cb0f0f; }
+.status-banner.status-proven { background: #2e7d32; }
+.status-banner.status-concept { background: #0277bd; }
+.status-banner.status-legacy { background: #cb0f0f; }

--- a/docs/css/status-banner.css
+++ b/docs/css/status-banner.css
@@ -20,8 +20,8 @@
 }
 
 .status-banner.status-proven,
-.status-badge.status-proven { background: #2ecc71; }
+.status-badge.status-proven { background: #2e7d32; }
 .status-banner.status-concept,
-.status-badge.status-concept { background: #3498db; }
+.status-badge.status-concept { background: #0277bd; }
 .status-banner.status-legacy,
-.status-badge.status-legacy { background: #f39c12; }
+.status-badge.status-legacy { background: #cb0f0f; }

--- a/docs/projects/neck-weight/v1-shot-inner-tube.md
+++ b/docs/projects/neck-weight/v1-shot-inner-tube.md
@@ -1,7 +1,7 @@
 ---
 title: Neck weight v1 — shot in inner tube
 version: v1
-status: active
+status: proven
 maturity: stable
 estimated_cost:
   - amount: 10

--- a/docs/projects/neck-weight/v2-molded-sleeve.md
+++ b/docs/projects/neck-weight/v2-molded-sleeve.md
@@ -1,7 +1,7 @@
 ---
 title: Neck weight v2 — molded sleeve
 version: v2
-status: active
+status: proven
 maturity: stable
 estimated_cost:
   - amount: 10

--- a/docs/projects/short-fins/v1/power-fin.md
+++ b/docs/projects/short-fins/v1/power-fin.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: proven
 techniques:
   - title: Foot pockets
     focus: Choosing the foot pockets

--- a/docs/techniques/choosing-bifin-footpockets/v1/short-rails.md
+++ b/docs/techniques/choosing-bifin-footpockets/v1/short-rails.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: proven
 bill_of_materials:
   - material: materials/bifin-footpockets.md
     description: Pair of angled freediving pockets with short rails

--- a/docs/techniques/creating-laminating-base/v1/wood-support.md
+++ b/docs/techniques/creating-laminating-base/v1/wood-support.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: proven
 time_to_implement: 1
 waiting_time: 0
 tools_required:

--- a/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
+++ b/docs/techniques/creating-laminating-base/v2/acrylic-wedges.md
@@ -1,5 +1,5 @@
 ---
-status: research
+status: concept
 time_to_implement: 1
 waiting_time: 0
 tools_required:

--- a/docs/techniques/cutting-cured-carbon/v1/junior-hacksaw.md
+++ b/docs/techniques/cutting-cured-carbon/v1/junior-hacksaw.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: proven
 time_to_implement: 1
 waiting_time: 0
 tools_required:

--- a/docs/techniques/cutting-template/v1/paper-laminate.md
+++ b/docs/techniques/cutting-template/v1/paper-laminate.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: proven
 time_to_implement: 0.5
 waiting_time: 0
 tools_required:

--- a/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
+++ b/docs/techniques/finishing-carbon/v1/epoxy-and-clear-coat.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: proven
 time_to_implement: 1
 waiting_time: 4
 tools_required:

--- a/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
+++ b/docs/techniques/gluing-fin-rails/v1/two-part-plastic-carbon-adhesive.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: proven
 time_to_implement: 0.5
 waiting_time: 12
 tools_required:

--- a/docs/techniques/laminating-carbon/v1/wet-layup.md
+++ b/docs/techniques/laminating-carbon/v1/wet-layup.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: proven
 time_to_implement: 1
 waiting_time: 12
 tools_required:

--- a/docs/techniques/measuring-flex/v1/weight-belt-test.md
+++ b/docs/techniques/measuring-flex/v1/weight-belt-test.md
@@ -1,5 +1,5 @@
 ---
-status: superseded
+status: legacy
 time_to_implement: 0.25
 waiting_time: 0
 tools_required:

--- a/docs/techniques/measuring-flex/v2/kitchen-scale-test.md
+++ b/docs/techniques/measuring-flex/v2/kitchen-scale-test.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: proven
 time_to_implement: 0.25
 waiting_time: 0
 tools_required:

--- a/docs/techniques/measuring-vacuum/v1/syringe-gauge.md
+++ b/docs/techniques/measuring-vacuum/v1/syringe-gauge.md
@@ -1,5 +1,5 @@
 ---
-status: research
+status: concept
 time_to_implement: 1
 waiting_time: 0
 tools_required:

--- a/docs/techniques/predicting-flex/v1/tapered-cantilever-beam.md
+++ b/docs/techniques/predicting-flex/v1/tapered-cantilever-beam.md
@@ -1,5 +1,5 @@
 ---
-status: research
+status: concept
 ---
 # {{ parent_child_title() }}
 {{ status_banner() }}

--- a/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v1/enclosed-bagging.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: proven
 bill_of_materials:
   - material: materials/vacuum-bagging-kit.md
     description: Heavy-duty storage bag plus compatible hand pump

--- a/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
+++ b/docs/techniques/vacuum-bagging-carbon/v2/edge-sealed-bagging.md
@@ -1,5 +1,5 @@
 ---
-status: research
+status: concept
 bill_of_materials:
   - material: materials/vacuum-bagging-kit.md
     description: Manual pump with heavy-duty storage bags for low-cost vacuum pulls

--- a/main.py
+++ b/main.py
@@ -871,16 +871,12 @@ def define_env(env):
             status = meta.get("status", "")
             if status:
                 normalized_status = status.strip().lower().replace(" ", "-")
-                status_class = normalized_status
                 status_text = status_labels.get(
                     normalized_status, status.strip().title()
                 )
                 icon = status_icons.get(normalized_status, "")
                 icon_prefix = f"{icon} " if icon else ""
-                status_html = (
-                    f'{icon_prefix}<span class="status-badge status-{status_class}">' 
-                    f"{status_text}</span>"
-                )
+                status_html = f"{icon_prefix}{status_text}"
             else:
                 status_html = ""
 

--- a/main.py
+++ b/main.py
@@ -835,6 +835,16 @@ def define_env(env):
             return nav_lookup
 
         nav_titles = build_nav_lookup()
+        status_icons = {
+            "proven": "✅",
+            "concept": "🧪",
+            "legacy": "⏳",
+        }
+        status_labels = {
+            "proven": "Proven",
+            "concept": "Concept",
+            "legacy": "Legacy",
+        }
         rows = []
         for file in sorted(base.glob("**/*.md")):
             if file.name == "index.md":
@@ -860,9 +870,17 @@ def define_env(env):
             wait_display = _format_hours_display(summary.get("waiting"))
             status = meta.get("status", "")
             if status:
-                status_class = status.lower().replace(" ", "-")
-                status_text = status.title()
-                status_html = f'<span class="status-badge status-{status_class}">{status_text}</span>'
+                normalized_status = status.strip().lower().replace(" ", "-")
+                status_class = normalized_status
+                status_text = status_labels.get(
+                    normalized_status, status.strip().title()
+                )
+                icon = status_icons.get(normalized_status, "")
+                icon_prefix = f"{icon} " if icon else ""
+                status_html = (
+                    f'{icon_prefix}<span class="status-badge status-{status_class}">' 
+                    f"{status_text}</span>"
+                )
             else:
                 status_html = ""
 


### PR DESCRIPTION
## Summary
- update the status badge styling to the new proven/concept/legacy colors
- show the matching emoji icon alongside status badges in generated tables
- rename project and technique frontmatter to use the new status labels

## Testing
- mkdocs build -f mkdocs.main.yml

------
https://chatgpt.com/codex/tasks/task_e_68e4d6bb8cb4832ca2183013a612e673