### PR TITLE
Add projects overview table macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Macros live in `main.py`.
 
 - `{{ yt("VIDEO_ID", "Title") }}` embeds a responsive privacy friendly YouTube iframe
 - `{{ versions_table() }}` builds a version comparison table for the current folder based on front matter metadata
+- `{{ projects_versions_table() }}` lists every project and its documented versions with status badges
 - `{{ status_banner() }}` shows a coloured banner with the current page status
 - `{{ render_tools_required() }}` outputs the front matter tools list as a table with optional links and notes;
   each tool entry must provide a `name` and `purpose`

--- a/docs/projects/index.md
+++ b/docs/projects/index.md
@@ -1,12 +1,5 @@
 # Projects
 
-Explore every build we are documenting in the lab. Each project index collects the current version notes, BOM, and testing logs so you can replicate or remix the work.
+Explore every build we are documenting in the lab. Each project index collects the current version notes, bill of materials, and testing logs so you can replicate or remix the work.
 
-## Short fins
-- [Short fins versions](short-fins/index.md): laminated blades tuned for pool dynamics with compress layups and flex measurements.
-
-## Neck weight
-- [Neck weight versions](neck-weight/index.md): modular ballast systems with molded sleeves and quick-adjust ballast pods.
-
-## Future gear
-- [(Future gear) experiments](future-gear/index.md): prototypes that are being sketched, tested, and refined before they graduate into full projects.
+{{ projects_versions_table() }}


### PR DESCRIPTION
## Summary
- add shared helpers for rendering status labels and looking up navigation metadata for macros
- implement a `projects_versions_table` macro to list every project version with status badges and hook it into the projects index
- document the new macro alongside the other available macros

## Testing
- mkdocs build -f mkdocs.local.yml --site-dir site

------
https://chatgpt.com/codex/tasks/task_e_68e55d9e73dc832c9fe5510dfd327d01